### PR TITLE
[osx] Update software definition for Mac OS X build 

### DIFF
--- a/config/patches/cmake/build_on_mac_10.10.patch
+++ b/config/patches/cmake/build_on_mac_10.10.patch
@@ -1,0 +1,16 @@
+--- cmake-3.1.3/Modules/Platform/Darwin.cmake	2015-02-11 11:17:39.000000000 -0500
++++ cmake-3.1.3/Modules/Platform/Darwin.cmake.new	2015-02-23 18:15:04.000000000 -0500
+@@ -73,12 +73,7 @@
+   elseif("${_CMAKE_OSX_SYSROOT_ORIG}" STREQUAL "/")
+     set(_sdk_ver "${_CURRENT_OSX_VERSION}")
+   else()
+-    message(FATAL_ERROR
+-      "CMAKE_OSX_DEPLOYMENT_TARGET is '${CMAKE_OSX_DEPLOYMENT_TARGET}' "
+-      "but CMAKE_OSX_SYSROOT:\n \"${_CMAKE_OSX_SYSROOT_ORIG}\"\n"
+-      "is not set to a MacOSX SDK with a recognized version.  "
+-      "Either set CMAKE_OSX_SYSROOT to a valid SDK or set "
+-      "CMAKE_OSX_DEPLOYMENT_TARGET to empty.")
++    set(_sdk_ver "${_CURRENT_OSX_VERSION}")
+   endif()
+   if(CMAKE_OSX_DEPLOYMENT_TARGET VERSION_GREATER "${_sdk_ver}")
+     message(FATAL_ERROR

--- a/config/patches/guidata/fix_blocking_import.patch
+++ b/config/patches/guidata/fix_blocking_import.patch
@@ -1,0 +1,9 @@
+--- guidata-1.6.1/guidata/qt/__init__.py	2013-05-13 10:41:24.000000000 -0400
++++ guidata-1.6.1/guidata/qt/__init__.py.new	2015-02-24 13:21:27.000000000 -0500
+@@ -56,5 +56,5 @@
+                   RuntimeWarning)
+     import PySide
+     __version__ = PySide.__version__
+-    from PySide import *
++    from PySide import QtGui, QtCore 
+     is_pyqt46 = False

--- a/config/patches/guidata/remove_default_image_path.patch
+++ b/config/patches/guidata/remove_default_image_path.patch
@@ -1,0 +1,10 @@
+--- guidata-1.6.1/guidata/config.py	2013-05-13 10:41:22.000000000 -0400
++++ guidata-1.6.1/guidata/config.py.new	2015-02-24 16:30:00.000000000 -0500
+@@ -16,7 +16,6 @@
+ from guidata.userconfig import UserConfig
+ 
+ APP_PATH = osp.dirname(__file__)
+-add_image_module_path("guidata", "images")
+ _ = get_translation("guidata")
+ 
+ DEFAULTS = {'arrayeditor':

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -41,7 +41,7 @@ env = {
 build do
   license "https://gist.githubusercontent.com/remh/227fefddabefc998235f/raw/cc614178cf79580e04671c4d6acfbe95028b1842/bzip2.LICENSE"
   patch :source => 'makefile_take_env_vars.patch'
-  patch :source => 'soname_install_dir.patch' if mac_os_x_mavericks?
+  patch :source => 'soname_install_dir.patch'#fixme do something according to the platform
   command "make PREFIX=#{prefix} VERSION=#{version}", :env => env
   command "make PREFIX=#{prefix} VERSION=#{version} -f Makefile-libbz2_so", :env => env
   command "make install VERSION=#{version} PREFIX=#{prefix}", :env => env

--- a/config/software/cmake.rb
+++ b/config/software/cmake.rb
@@ -1,0 +1,15 @@
+name 'cmake'
+
+default_version '3.1.3'
+
+source :url => "http://www.cmake.org/files/v#{version[0..2]}/cmake-#{version}.tar.gz",
+       :md5 => '5697a77503bb5636f4b4057dcc02aa32'
+
+relative_path "cmake-#{version}"
+
+build do
+  command './configure'
+  patch :source => "build_on_mac_10.10.patch" if Ohai['platform_family'] == 'mac_os_x'
+  command "make -j #{workers}"
+  command "make install"
+end

--- a/config/software/go.rb
+++ b/config/software/go.rb
@@ -1,0 +1,9 @@
+name "go"
+default_version "1.4.2"
+
+if Ohai['platform_family'] == 'mac_os_x'
+	depends 'homebrew'
+	build do
+	   command "brew install go"
+	end
+end

--- a/config/software/gui.rb
+++ b/config/software/gui.rb
@@ -1,0 +1,9 @@
+# This is a fake software gathering all depencies needed for the agent GUI
+name 'gui'
+default_version '5.3.0'
+
+dependency 'guidata'
+dependency 'spyderlib'
+if Ohai['platform_family'] == 'mac_os_x'
+	dependency 'py2app'
+end

--- a/config/software/guidata.rb
+++ b/config/software/guidata.rb
@@ -1,0 +1,21 @@
+name 'guidata'
+
+default_version '1.6.1'
+
+dependency 'pyside'
+
+source :url => "https://guidata.googlecode.com/files/guidata-#{version}.zip",
+	   :md5 => '47d625f998b5092ba797c8657979aa94'
+       # :sha1 => 'abc80daf473562eb6132c2245d8108afe6451645'
+
+relative_path "guidata-#{version}"
+
+env = {
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}"
+}
+
+build do
+  patch :source => 'fix_blocking_import.patch'
+  patch :source => 'remove_default_image_path.patch' if Ohai['platform_family'] == 'mac_os_x'
+  command "#{install_dir}/embedded/bin/python setup.py install", :env => env
+end

--- a/config/software/guidata.rb
+++ b/config/software/guidata.rb
@@ -17,5 +17,6 @@ env = {
 build do
   patch :source => 'fix_blocking_import.patch'
   patch :source => 'remove_default_image_path.patch' if Ohai['platform_family'] == 'mac_os_x'
-  command "#{install_dir}/embedded/bin/python setup.py install", :env => env
+  command "#{install_dir}/embedded/bin/python setup.py install "\
+		  "--record #{install_dir}/embedded/guidata-files.txt", :env => env
 end

--- a/config/software/help2man.rb
+++ b/config/software/help2man.rb
@@ -25,6 +25,6 @@ relative_path "help2man-1.40.5"
 
 build do
   command "./configure --prefix=#{install_dir}/embedded"
-  command "make"
+  command "make -j #{workers}"
   command "make install"
 end

--- a/config/software/homebrew.rb
+++ b/config/software/homebrew.rb
@@ -1,0 +1,12 @@
+name "homebrew"
+
+default_version "0"
+
+install_url = 'https://raw.githubusercontent.com/Homebrew/install/master/install'
+
+build do
+  command "echo | "\
+  		  "ruby -e \"$(curl -fsSL #{install_url})\" |"\
+  		  " echo \"Brew already installed\""
+  command "brew update"
+end

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -45,6 +45,6 @@ build do
     --disable-bsdcpio \
     --without-lzmadec \
     --without-openssl", :env => env
-  command "make", :env => env
+  command "make -j #{workers}", :env => env
   command "make install", :env => env
 end

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -40,6 +40,6 @@ build do
   else
     command "./configure --prefix=/tmp/build/embedded", :env => env
   end
-  command "make", :env => env
+  command "make -j #{workers}", :env => env
   command "make install", :env => env
 end

--- a/config/software/perl-extutils-embed.rb
+++ b/config/software/perl-extutils-embed.rb
@@ -10,6 +10,6 @@ relative_path "ExtUtils-Embed-#{version}"
 
 build do
     command "#{install_dir}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_dir}/embedded"
-    command "make"
+    command "make -j #{workers}"
     command "make install"
 end

--- a/config/software/perl-extutils-makemaker.rb
+++ b/config/software/perl-extutils-makemaker.rb
@@ -10,6 +10,6 @@ relative_path "ExtUtils-MakeMaker-#{version}"
 
 build do
     command "#{install_dir}/embedded/bin/perl Makefile.PL INSTALL_BASE=#{install_dir}/embedded"
-    command "make"
+    command "make -j #{workers}"
     command "make install"
 end

--- a/config/software/py2app.rb
+++ b/config/software/py2app.rb
@@ -1,0 +1,12 @@
+name 'py2app'
+
+default_version '0.9.0'
+dependency 'pip'
+
+env = {
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"
+}
+
+build do
+  command "#{install_dir}/embedded/bin/pip install -U py2app", :env => env
+end

--- a/config/software/pycurl.rb
+++ b/config/software/pycurl.rb
@@ -10,7 +10,8 @@ dependency "libgcc" if (Ohai['platform'] == "solaris2" and Omnibus.config.solari
 build do
   license "https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT"
   build_env = {
-    "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}"
+    "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}",
+    "ARCHFLAGS" => "-arch x86_64"
   }
   command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}", :env => build_env
 end

--- a/config/software/pyside.rb
+++ b/config/software/pyside.rb
@@ -16,5 +16,6 @@ env = {
 }
 
 build do
-  command "#{install_dir}/embedded/bin/python setup.py install", :env => env
+  command "#{install_dir}/embedded/bin/python setup.py install "\
+          "--record #{install_dir}/embedded//pyside-files.txt", :env => env
 end

--- a/config/software/pyside.rb
+++ b/config/software/pyside.rb
@@ -1,0 +1,20 @@
+name 'pyside'
+
+default_version '1.2.2'
+
+dependency 'python'
+dependency 'cmake'
+dependency 'qt'
+
+source :url => "https://pypi.python.org/packages/source/P/PySide/PySide-#{version}.tar.gz",
+       :md5 => 'c45bc400c8a86d6b35f34c29e379e44d'
+
+relative_path "PySide-#{version}"
+
+env = {
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"
+}
+
+build do
+  command "#{install_dir}/embedded/bin/python setup.py install", :env => env
+end

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -33,13 +33,21 @@ env = {
   "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
 }
 
+python_configure = ["./configure",
+                    "--enable-universalsdk=/",
+                    "--prefix=#{install_dir}/embedded"]
+
+if ENV['PKG_TYPE'] == 'dmg'
+  python_configure.push('--enable-ipv6', '--with-universal-archs=intel')
+end
+
+python_configure.push("--with-dbmliborder=")
+
 build do
   license "PSFL"
-  command ["./configure",
-           "--prefix=#{install_dir}/embedded",
-           "--enable-shared",
-           "--with-dbmliborder="].join(" "), :env => env
-  command "make", :env => env
+  command python_configure.join(" "), :env => env
+  patch :source => "disable_sslv3.patch" if ENV['PKG_TYPE'] == 'dmg'
+  command "make -j #{workers}", :env => env
   command "make install", :env => env
   command "rm -rf #{install_dir}/embedded/lib/python2.7/test"
 

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -37,8 +37,10 @@ python_configure = ["./configure",
                     "--enable-universalsdk=/",
                     "--prefix=#{install_dir}/embedded"]
 
-if ENV['PKG_TYPE'] == 'dmg'
-  python_configure.push('--enable-ipv6', '--with-universal-archs=intel')
+if Ohai['platform_family'] == 'mac_os_x' 
+  python_configure.push('--enable-ipv6',
+                        '--with-universal-archs=intel',
+                        '--enable-shared')
 end
 
 python_configure.push("--with-dbmliborder=")
@@ -46,7 +48,7 @@ python_configure.push("--with-dbmliborder=")
 build do
   license "PSFL"
   command python_configure.join(" "), :env => env
-  patch :source => "disable_sslv3.patch" if ENV['PKG_TYPE'] == 'dmg'
+  patch :source => "disable_sslv3.patch" if Ohai['platform_family'] == 'mac_os_x'
   command "make -j #{workers}", :env => env
   command "make install", :env => env
   command "rm -rf #{install_dir}/embedded/lib/python2.7/test"

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -37,7 +37,7 @@ python_configure = ["./configure",
                     "--enable-universalsdk=/",
                     "--prefix=#{install_dir}/embedded"]
 
-if Ohai['platform_family'] == 'mac_os_x' 
+if Ohai['platform_family'] == 'mac_os_x'
   python_configure.push('--enable-ipv6',
                         '--with-universal-archs=intel',
                         '--enable-shared')

--- a/config/software/qt.rb
+++ b/config/software/qt.rb
@@ -1,0 +1,10 @@
+name "qt"
+
+default_version "4.8"
+
+dependency "homebrew"
+
+build do
+  command "brew install qt"
+  command "brew linkapps qt"
+end

--- a/config/software/relx.rb
+++ b/config/software/relx.rb
@@ -38,6 +38,6 @@ env = {
 }
 
 build do
-  command "make", :env => env
+  command "make -j #{workers}", :env => env
   command "cp ./relx #{install_dir}/embedded/bin/"
 end

--- a/config/software/runit.rb
+++ b/config/software/runit.rb
@@ -32,7 +32,7 @@ build do
   command "sed -i -e s:-static:: src/Makefile", :cwd => working_dir
 
   # build it
-  command "make", :cwd => "#{working_dir}/src"
+  command "make -j #{workers}", :cwd => "#{working_dir}/src"
   command "make check", :cwd => "#{working_dir}/src"
 
   # move it

--- a/config/software/spidermonkey.rb
+++ b/config/software/spidermonkey.rb
@@ -36,14 +36,14 @@ working_dir = "#{project_dir}/src"
 #
 
 build do
-  command(["make",
+  command(["make -j #{workers}",
            "BUILD_OPT=1",
            "XCFLAGS=-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
            "-f",
            "Makefile.ref"].join(" "),
           :env => env,
           :cwd => working_dir)
-  command(["make",
+  command(["make -j #{workers}",
            "BUILD_OPT=1",
            "JS_DIST=#{install_dir}/embedded",
            "-f",

--- a/config/software/spyderlib.rb
+++ b/config/software/spyderlib.rb
@@ -14,5 +14,6 @@ env = {
 }
 
 build do
-  command "#{install_dir}/embedded/bin/python setup.py install", :env => env
+  command "#{install_dir}/embedded/bin/python setup.py install "\
+          "--record #{install_dir}/embedded//spyderlib-files.txt", :env => env
 end

--- a/config/software/spyderlib.rb
+++ b/config/software/spyderlib.rb
@@ -1,0 +1,18 @@
+name 'spyderlib'
+
+default_version '2.3.2'
+
+dependency 'guidata'
+
+source :url => "https://github.com/spyder-ide/spyder/archive/v#{version}.tar.gz",
+       :md5 => 'a67dfcc612b95ca9a627e30a28aebd37'
+
+relative_path "spyder-#{version}"
+
+env = {
+  "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}"
+}
+
+build do
+  command "#{install_dir}/embedded/bin/python setup.py install", :env => env
+end

--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -4,20 +4,7 @@ default_version "3.1.3"
 dependency "python"
 dependency "pip"
 
-# Otherwise py2app doesn't find supervisor module
-if Ohai['platform_family'] == 'mac_os_x'
-	source :url => "https://github.com/Supervisor/supervisor/archive/#{version}.tar.gz",
-		   :md5 => '073f1912e8bfe5bf89e84b96495df62e'
-
-	relative_path "supervisor-#{version}"
-
-	build do
-	  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
-	  command "#{install_dir}/embedded/bin/python setup.py install"
-	end
-else
-	build do
-	  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
-	  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
-	end
+build do
+  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
+  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -4,7 +4,20 @@ default_version "3.1.3"
 dependency "python"
 dependency "pip"
 
-build do
-  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+# Otherwise py2app doesn't find supervisor module
+if Ohai['platform_family'] == 'mac_os_x'
+	source :url => "https://github.com/Supervisor/supervisor/archive/#{version}.tar.gz",
+		   :md5 => '073f1912e8bfe5bf89e84b96495df62e'
+
+	relative_path "supervisor-#{version}"
+
+	build do
+	  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
+	  command "#{install_dir}/embedded/bin/python setup.py install"
+	end
+else
+	build do
+	  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
+	  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+	end
 end

--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -21,4 +21,4 @@ build do
     :env => env)
   command "make -j #{workers}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
-  end
+end


### PR DESCRIPTION
Are the `command "sudo chown -R vagrant #{install_dir}"` needed for deb/rpm builds ? (the only one really problematic being `config/software/libsqlite3.rb`, systat is not used on Mac)

Main changes are for the python installer, should not break the other builds. (except the chown part ?)

Related:
- https://github.com/DataDog/dd-agent/pull/1361
- https://github.com/DataDog/dd-agent-omnibus/pull/11