### PR TITLE
Etienne/omnibus 4 migration

### DIFF
--- a/config/software/adodbapi.rb
+++ b/config/software/adodbapi.rb
@@ -6,6 +6,6 @@ dependency "pip"
 dependency "pyro4"
 
 build do
-  license "LGPLv2"
+  ship_license "LGPLv2"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/boto.rb
+++ b/config/software/boto.rb
@@ -4,6 +4,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/boto/boto/develop/LICENSE"
+  ship_license "https://raw.githubusercontent.com/boto/boto/develop/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/bundler.rb
+++ b/config/software/bundler.rb
@@ -18,7 +18,7 @@
 name "bundler"
 default_version "1.5.3"
 
-if Ohai['platform'] == 'windows'
+if ohai['platform'] == 'windows'
   dependency "ruby-windows"
 else
   dependency "rubygems"

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -39,7 +39,7 @@ env = {
 }
 
 build do
-  license "https://gist.githubusercontent.com/remh/227fefddabefc998235f/raw/cc614178cf79580e04671c4d6acfbe95028b1842/bzip2.LICENSE"
+  ship_license "https://gist.githubusercontent.com/remh/227fefddabefc998235f/raw/cc614178cf79580e04671c4d6acfbe95028b1842/bzip2.LICENSE"
   patch :source => 'makefile_take_env_vars.patch'
   patch :source => 'soname_install_dir.patch' if mac_os_x_mavericks?
   command "make PREFIX=#{prefix} VERSION=#{version}", :env => env

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -63,11 +63,11 @@ build do
     # fix worked. Rather than trying to fix this now, we're filing a bug and copying the cacert.pem
     # directly from the cache instead.
 
-    FileUtils.cp(File.expand_path("cacert.pem", Config.cache_dir),
-                 File.expand_path("embedded/ssl/certs/cacert.pem", install_dir))
+    # FileUtils.cp(File.expand_path("cacert.pem", Config.cache_dir),
+    #              File.expand_path("embedded/ssl/certs/cacert.pem", install_dir))
   end
 
-  unless Ohai['platform'] == 'windows'
+  unless ohai['platform'] == 'windows'
     command "ln -sf #{install_dir}/embedded/ssl/certs/cacert.pem #{install_dir}/embedded/ssl/cert.pem"
   end
 end

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -52,7 +52,7 @@ source :url => "http://curl.haxx.se/ca/cacert.pem"
 relative_path "cacerts-#{version}"
 
 build do
-  license "http://www.r-project.org/Licenses/LGPL-2.1"
+  ship_license "http://www.r-project.org/Licenses/LGPL-2.1"
   block do
     FileUtils.mkdir_p(File.expand_path("embedded/ssl/certs", install_dir))
 

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -27,7 +27,7 @@ source :url => "http://curl.haxx.se/download/curl-#{version}.tar.gz",
 relative_path "curl-#{version}"
 
 build do
-  license "https://raw.githubusercontent.com/bagder/curl/master/COPYING"
+  ship_license "https://raw.githubusercontent.com/bagder/curl/master/COPYING"
   block do
     FileUtils.rm_rf(File.join(project_dir, 'src/tool_hugehelp.c'))
   end

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,6 +1,5 @@
 name "datadog-gohai"
 default_version "last-stable"
-# always_build true
 
 env = {
   "GOROOT" => "/usr/local/go",

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,6 +1,6 @@
 name "datadog-gohai"
 default_version "last-stable"
-always_build true
+# always_build true
 
 env = {
   "GOROOT" => "/usr/local/go",

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -8,7 +8,7 @@ env = {
 }
 
 build do
-   license "https://raw.githubusercontent.com/DataDog/gohai/master/LICENSE"
+   ship_license "https://raw.githubusercontent.com/DataDog/gohai/master/LICENSE"
    command "$GOROOT/bin/go get -d -u github.com/DataDog/gohai", :env => env
    command "git checkout #{default_version} && git pull", :env => env, :cwd => "/var/cache/omnibus/src/datadog-gohai/src/github.com/DataDog/gohai"
    command "$GOROOT/bin/go build -o #{install_dir}/bin/gohai $GOPATH/src/github.com/DataDog/gohai/gohai.go", :env => env

--- a/config/software/futures.rb
+++ b/config/software/futures.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://pythonfutures.googlecode.com/hg/LICENSE"
+  ship_license "https://pythonfutures.googlecode.com/hg/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -26,7 +26,7 @@ source :url => "http://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz",
 relative_path "gdbm-#{version}"
 
 build do
-  env = case Ohai['platform']
+  env = case ohai['platform']
   when "solaris2"
     {
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -R#{install_dir}/embedded/lib",
@@ -46,7 +46,7 @@ build do
                        "--enable-libgdbm-compat",
                        "--prefix=#{install_dir}/embedded"]
 
-  if Ohai['platform'] == "freebsd"
+  if ohai['platform'] == "freebsd"
     configure_command << "--with-pic"
   end
 

--- a/config/software/httplib2.rb
+++ b/config/software/httplib2.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/jcgregorio/httplib2/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/jcgregorio/httplib2/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/jre.rb
+++ b/config/software/jre.rb
@@ -25,7 +25,7 @@ whitelist_file "jre/bin/policytool"
 whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 
-if Ohai['kernel']['machine'] =~ /x86_64/
+if ohai['kernel']['machine'] =~ /x86_64/
   # TODO: download x86 version on x86 machines
   source :url => "http://download.oracle.com/otn-pub/java/jdk/7u3-b04/jre-7u3-linux-x64.tar.gz",
          :md5 => "3d3e206cea84129f1daa8e62bf656a28",

--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -6,6 +6,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "Apachev2"
+  ship_license "Apachev2"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/kazoo.rb
+++ b/config/software/kazoo.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "Apachev2"
+  ship_license "Apachev2"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -56,7 +56,7 @@ env = case Ohai['platform']
       end
 
 build do
-  license "https://gist.githubusercontent.com/remh/d001e1be55cd07a88550/raw/742f005f8f9c744a4c7c8b2a0e6c3018546d6d0c/libedit.LICENSE"
+  ship_license "https://gist.githubusercontent.com/remh/d001e1be55cd07a88550/raw/742f005f8f9c744a4c7c8b2a0e6c3018546d6d0c/libedit.LICENSE"
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
   if Ohai['platform'] == "freebsd"

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -33,7 +33,7 @@ source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz"
 
 relative_path "libedit-#{version}"
 
-env = case Ohai['platform']
+env = case ohai['platform']
       when "aix"
         {
           "CC" => "xlc -q64",
@@ -59,7 +59,7 @@ build do
   ship_license "https://gist.githubusercontent.com/remh/d001e1be55cd07a88550/raw/742f005f8f9c744a4c7c8b2a0e6c3018546d6d0c/libedit.LICENSE"
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
-  if Ohai['platform'] == "freebsd"
+  if ohai['platform'] == "freebsd"
     patch :source => "freebsd-vi-fix.patch"
   end
   command ["./configure",

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -30,7 +30,7 @@ env = with_embedded_path()
 env = with_standard_compiler_flags(env)
 
 build do
-  license "https://raw.githubusercontent.com/atgreen/libffi/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/atgreen/libffi/master/LICENSE"
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}", :env => env
   command "make -j #{workers} install", :env => env

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -35,13 +35,13 @@ build do
   command "make -j #{workers}", :env => env
   command "make -j #{workers} install", :env => env
   # libffi's default install location of header files is awful...
-  command "cp -f #{install_dir}/embedded/lib/libffi-3.0.13/include/* #{install_dir}/embedded/include"
+  copy "#{install_dir}/embedded/lib/libffi-3.0.13/include/*", "#{install_dir}/embedded/include"
 
   # On 64-bit centos, libffi libraries are places under /embedded/lib64
   # move them over to lib
   if rhel? && _64_bit?
-    command "mv #{install_dir}/embedded/lib64/* #{install_dir}/embedded/lib/"
-    command "rm -rf #{install_dir}/embedded/lib64"
+    move "#{install_dir}/embedded/lib64/*", "#{install_dir}/embedded/lib/"
+    delete "#{install_dir}/embedded/lib64"
   end
 end
 

--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -26,7 +26,7 @@ description "On UNIX systems where we bootstrap a compiler, copy the libgcc"
 default_version "0.0.1"
 
 libgcc_file =
-  case Ohai['platform']
+  case ohai['platform']
   when "solaris2"
     "/opt/csw/lib/libgcc_s.so.1"
   when "aix"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -25,7 +25,7 @@ source :url => "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
 
 relative_path "libiconv-#{version}"
 
-env = case Ohai['platform']
+env = case ohai['platform']
       when "aix"
         {
           "CC" => "xlc -q64",
@@ -44,7 +44,7 @@ env = case Ohai['platform']
         }
       end
 
-if Ohai['platform'] == "solaris2"
+if ohai['platform'] == "solaris2"
   env.merge!({"LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc", "LD_OPTIONS" => "-R#{install_dir}/embedded/lib"})
 end
 

--- a/config/software/libpq.rb
+++ b/config/software/libpq.rb
@@ -18,7 +18,7 @@ env = {
 }
 
 build do
-  license "https://raw.githubusercontent.com/lpsmith/postgresql-libpq/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/lpsmith/postgresql-libpq/master/LICENSE"
   command [ "./configure",
             "--prefix=#{install_dir}/embedded",
             "--with-libedit-preferred",

--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -18,5 +18,5 @@ build do
     :env => env)
   command "make -j #{workers}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
-  command "rm  #{install_dir}/embedded/bin/sqlite3"
+  delete "#{install_dir}/embedded/bin/sqlite3"
 end

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -35,7 +35,7 @@ env = with_standard_compiler_flags(env, :aix => { :use_gcc => true })
 
 build do
    command "mkdir -p /tmp/build/embedded"
-  if Ohai['platform'] == "aix"
+  if ohai['platform'] == "aix"
     command "./configure --prefix=/tmp/build/embedded --with-gcc", :env => env
   else
     command "./configure --prefix=/tmp/build/embedded", :env => env

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -19,7 +19,7 @@ name "libxslt"
 default_version "1.1.28"
 
 dependency "libxml2"
-dependency "libtool" if Ohai['platform'] == "solaris2"
+dependency "libtool" if ohai['platform'] == "solaris2"
 dependency "liblzma"
 
 version "1.1.26" do

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -27,7 +27,7 @@ env = with_embedded_path()
 env = with_standard_compiler_flags(env)
 
 build do
-  license "https://raw.githubusercontent.com/yaml/libyaml/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/yaml/libyaml/master/LICENSE"
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}", :env => env
   command "make -j #{workers} install", :env => env

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -67,7 +67,7 @@ configure_env["PKG_CONFIG_PATH"] = "#{install_dir}/embedded/lib/pkgconfig" +
 configure_env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
 build do
-  license "https://raw.githubusercontent.com/ioerror/makedepend/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/ioerror/makedepend/master/LICENSE"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -28,7 +28,7 @@ dependency 'util-macros'
 dependency 'pkg-config'
 
 configure_env =
-  case Ohai['platform']
+  case ohai['platform']
   when "aix"
     {
       "CC" => "xlc -q64",

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -57,7 +57,7 @@ end
 ########################################################################
 
 build do
-  license "https://gist.githubusercontent.com/remh/41a4f7433c77841c302c/raw/d15db09a192ca0e51022005bfb4c3a414a996896/ncurse.LICENSE"
+  ship_license "https://gist.githubusercontent.com/remh/41a4f7433c77841c302c/raw/d15db09a192ca0e51022005bfb4c3a414a996896/ncurse.LICENSE"
   if Ohai['platform'] == "smartos"
     # SmartOS is Illumos Kernel, plus NetBSD userland with a GNU toolchain.
     # These patches are taken from NetBSD pkgsrc and provide GCC 4.7.0

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -19,7 +19,7 @@ name "ncurses"
 default_version "5.9"
 
 dependency "libgcc"
-dependency "libtool" if Ohai['platform'] == "aix"
+dependency "libtool" if ohai['platform'] == "aix"
 
 source url: "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
        md5: "8cb9c412e5f2d96bc6f459aa8c6282a1"
@@ -29,7 +29,7 @@ relative_path "ncurses-5.9"
 env = with_embedded_path()
 env = with_standard_compiler_flags(env, aix: { use_gcc: true })
 
-if Ohai['platform'] == "solaris2"
+if ohai['platform'] == "solaris2"
   # gcc4 from opencsw fails to compile ncurses
   env.merge!({"PATH" => "/opt/csw/gcc3/bin:/opt/csw/bin:/usr/local/bin:/usr/sfw/bin:/usr/ccs/bin:/usr/sbin:/usr/bin"})
   env.merge!({"CC" => "/opt/csw/gcc3/bin/gcc"})
@@ -37,7 +37,7 @@ if Ohai['platform'] == "solaris2"
 end
 
 # FIXME: validate omnibus-ruby sets this correctly on smartos now via with_standard_compiler_flagS()
-#elsif Ohai['platform'] == "smartos"
+#elsif ohai['platform'] == "smartos"
 #  env.merge!({"LD_OPTIONS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib "})
 #end
 
@@ -58,7 +58,7 @@ end
 
 build do
   ship_license "https://gist.githubusercontent.com/remh/41a4f7433c77841c302c/raw/d15db09a192ca0e51022005bfb4c3a414a996896/ncurse.LICENSE"
-  if Ohai['platform'] == "smartos"
+  if ohai['platform'] == "smartos"
     # SmartOS is Illumos Kernel, plus NetBSD userland with a GNU toolchain.
     # These patches are taken from NetBSD pkgsrc and provide GCC 4.7.0
     # compatibility:
@@ -76,11 +76,11 @@ build do
     patch source: 'ncurses-5.9-solaris-xopen_source_extended-detection.patch', plevel: 0
   end
 
-  if Ohai['platform'] == "aix"
+  if ohai['platform'] == "aix"
     patch source: 'patch-aix-configure', plevel: 0
   end
 
-  if Ohai['platform'] == "mac_os_x"
+  if ohai['platform'] == "mac_os_x"
     # References:
     # https://github.com/Homebrew/homebrew-dupes/issues/43
     # http://invisible-island.net/ncurses/NEWS.html#t20110409
@@ -101,7 +101,7 @@ build do
            "--enable-overwrite",
            "--enable-widec"]
 
-  cmd_array << "--with-libtool" if Ohai['platform'] == 'aix'
+  cmd_array << "--with-libtool" if ohai['platform'] == 'aix'
   command(cmd_array.join(" "),
           env: env)
   command "make -j #{workers}", env: env
@@ -116,7 +116,7 @@ build do
            "--without-debug",
            "--without-normal",
            "--enable-overwrite"]
-  cmd_array << "--with-libtool" if Ohai['platform'] == 'aix'
+  cmd_array << "--with-libtool" if ohai['platform'] == 'aix'
   command(cmd_array.join(" "),
           env: env)
   command "make -j #{workers}", env: env
@@ -127,7 +127,7 @@ build do
   command "make -j #{workers} install", env: env
 
   # Ensure embedded ncurses wins in the LD search path
-  if Ohai['platform'] == "smartos"
+  if ohai['platform'] == "smartos"
     command "ln -sf #{install_dir}/embedded/lib/libcurses.so #{install_dir}/embedded/lib/libcurses.so.1"
   end
 end

--- a/config/software/nokogiri.rb
+++ b/config/software/nokogiri.rb
@@ -18,7 +18,7 @@
 name "nokogiri"
 default_version "1.6.2.1"
 
-if Ohai['platform'] == 'windows'
+if ohai['platform'] == 'windows'
   dependency "ruby-windows"
   dependency "ruby-windows-devkit"
 else

--- a/config/software/ntplib.rb
+++ b/config/software/ntplib.rb
@@ -5,8 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "LGPLv3"
-  license "GPLv2"
+  ship_license "LGPLv3"
+  ship_license "GPLv2"
   command "rm -rf /var/cache/omnibus/src/ntplib"
   command "#{install_dir}/embedded/bin/pip install --force-reinstall -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}", :cwd => "/tmp"
 end

--- a/config/software/ntplib.rb
+++ b/config/software/ntplib.rb
@@ -7,6 +7,6 @@ dependency "pip"
 build do
   ship_license "LGPLv3"
   ship_license "GPLv2"
-  command "rm -rf /var/cache/omnibus/src/ntplib"
+  delete "/var/cache/omnibus/src/ntplib"
   command "#{install_dir}/embedded/bin/pip install --force-reinstall -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}", :cwd => "/tmp"
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -142,7 +142,7 @@ build do
   else
     make_binary = 'make'
   end
-  license "https://raw.githubusercontent.com/openssl/openssl/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/openssl/openssl/master/LICENSE"
 
   command configure_command, :env => env
   command "#{make_binary} depend", :env => env

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -32,7 +32,7 @@ relative_path "openssl-#{version}"
 build do
   patch :source => "openssl-1.0.1f-do-not-build-docs.patch"
 
-  env = case Ohai['platform']
+  env = case ohai['platform']
         when "mac_os_x"
           {
             "CFLAGS" => "-arch x86_64 -m64 -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -I#{install_dir}/embedded/include/ncurses",
@@ -76,7 +76,7 @@ build do
     "no-ssl3"
   ].join(" ")
 
-  configure_command = case Ohai['platform']
+  configure_command = case ohai['platform']
                       when "aix"
                         ["perl", "./Configure",
                          "aix64-cc",

--- a/config/software/paramiko.rb
+++ b/config/software/paramiko.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/paramiko/paramiko/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/paramiko/paramiko/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pg8000.rb
+++ b/config/software/pg8000.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/mfenniak/pg8000/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/mfenniak/pg8000/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pip.rb
+++ b/config/software/pip.rb
@@ -26,6 +26,6 @@ source :url => "https://pypi.python.org/packages/source/p/pip/pip-#{version}.tar
 relative_path "pip-#{version}"
 
 build do
-  license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
+  ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
   command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
 end

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -34,7 +34,7 @@ env = with_standard_compiler_flags(env, :aix => { :use_gcc => true })
 paths = [ "#{install_dir}/embedded/bin/pkgconfig" ]
 
 build do
-  add_source "http://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
+  ship_source "http://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
   command "./configure --prefix=#{install_dir}/embedded --disable-debug --disable-host-tool --with-internal-glib --with-pc-path=#{paths*':'}", :env => env
   # #203: pkg-configs internal glib does not provide a way to pass ldflags.
   # Only allows GLIB_CFLAGS and GLIB_LIBS.

--- a/config/software/popt.rb
+++ b/config/software/popt.rb
@@ -24,7 +24,7 @@ source :url => "http://rpm5.org/files/popt/popt-1.16.tar.gz",
 relative_path "popt-1.16"
 
 env =
-  case Ohai['platform']
+  case ohai['platform']
   when "solaris2"
     {
       "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -1,8 +1,6 @@
 name "procps-ng"
 default_version "3.3.9"
 
-dependency "tar"
-
 source :url => "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz",
        :md5 => '0980646fa25e0be58f7afb6b98f79d74'
 

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -16,7 +16,7 @@ env = {
 
 build do
   add_source "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz"
-  license "https://gitorious.org/procps/procps/raw/fe559b5b3b089c9aa2b0816c1ca541b6679d1b6d:COPYING"
+  ship_license "https://gitorious.org/procps/procps/raw/fe559b5b3b089c9aa2b0816c1ca541b6679d1b6d:COPYING"
   command(["./configure",
      "--prefix=#{install_dir}/embedded",
      "--disable-nls"].join(" "),

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -15,14 +15,14 @@ env = {
 }
 
 build do
-  add_source "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz"
-  ship_license "https://gitorious.org/procps/procps/raw/fe559b5b3b089c9aa2b0816c1ca541b6679d1b6d:COPYING"
+  ship_source "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz"
+  # ship_license "https://gitorious.org/procps/procps/raw/fe559b5b3b089c9aa2b0816c1ca541b6679d1b6d:COPYING"
   command(["./configure",
      "--prefix=#{install_dir}/embedded",
-     "--disable-nls"].join(" "),
+     ""].join(" "),
   :env => env)
   command "make -j #{workers}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
   command "make install"
-  command "mv #{install_dir}/embedded/usr/bin/* #{install_dir}/embedded/bin/"
-  command "rm -rf #{install_dir}/embedded/usr/bin"
+  move "#{install_dir}/embedded/usr/bin/*", "#{install_dir}/embedded/bin/"
+  delete "#{install_dir}/embedded/usr/bin"
 end

--- a/config/software/psutil.rb
+++ b/config/software/psutil.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/psycopg2.rb
+++ b/config/software/psycopg2.rb
@@ -10,6 +10,6 @@ env = {
 }
 
 build do
-  license "https://raw.githubusercontent.com/psycopg/psycopg2/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/psycopg/psycopg2/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}", :env => env
 end

--- a/config/software/pycurl.rb
+++ b/config/software/pycurl.rb
@@ -8,7 +8,7 @@ dependency "gdbm" if (Ohai['platform'] == "mac_os_x" or Ohai['platform'] == "fre
 dependency "libgcc" if (Ohai['platform'] == "solaris2" and Omnibus.config.solaris_compiler == "gcc")
 
 build do
-  license "https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT"
+  ship_license "https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT"
   build_env = {
     "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}"
   }

--- a/config/software/pycurl.rb
+++ b/config/software/pycurl.rb
@@ -4,8 +4,8 @@ default_version "7.19.5.1"
 dependency "python"
 dependency "pip"
 dependency "curl"
-dependency "gdbm" if (Ohai['platform'] == "mac_os_x" or Ohai['platform'] == "freebsd" or Ohai['platform'] == "aix")
-dependency "libgcc" if (Ohai['platform'] == "solaris2" and Omnibus.config.solaris_compiler == "gcc")
+dependency "gdbm" if (ohai['platform'] == "mac_os_x" or ohai['platform'] == "freebsd" or ohai['platform'] == "aix")
+dependency "libgcc" if (ohai['platform'] == "solaris2" and Omnibus.config.solaris_compiler == "gcc")
 
 build do
   ship_license "https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT"

--- a/config/software/pymongo.rb
+++ b/config/software/pymongo.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "Apachev2"
+  ship_license "Apachev2"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pymysql.rb
+++ b/config/software/pymysql.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/PyMySQL/PyMySQL/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/PyMySQL/PyMySQL/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -7,7 +7,7 @@ dependency "pip"
 dependency "libffi"
 
 build do
-  license "https://raw.githubusercontent.com/pyca/pyopenssl/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/pyca/pyopenssl/master/LICENSE"
   build_env = {
     "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}",
     "LDFLAGS" => "-L/#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",

--- a/config/software/pyro4.rb
+++ b/config/software/pyro4.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/irmen/Pyro4/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/irmen/Pyro4/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" Pyro4==#{version}"
 end

--- a/config/software/pysnmp-mibs.rb
+++ b/config/software/pysnmp-mibs.rb
@@ -5,7 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"
+  ship_license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end
 

--- a/config/software/pysnmp.rb
+++ b/config/software/pysnmp.rb
@@ -6,6 +6,6 @@ dependency "pip"
 dependency "pysnmp-mibs"
 
 build do
-  license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"
+  ship_license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/python-gearman.rb
+++ b/config/software/python-gearman.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/Yelp/python-gearman/master/LICENSE.txt"
+  ship_license "https://raw.githubusercontent.com/Yelp/python-gearman/master/LICENSE.txt"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" gearman==#{version}"
 end

--- a/config/software/python-memcached.rb
+++ b/config/software/python-memcached.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "PSFL"
+  ship_license "PSFL"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/python-redis.rb
+++ b/config/software/python-redis.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/andymccurdy/redis-py/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/andymccurdy/redis-py/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" redis==#{version}"
 end

--- a/config/software/python-rrdtool.rb
+++ b/config/software/python-rrdtool.rb
@@ -3,7 +3,7 @@ default_version "1.3.8"
 dependency "python"
 
 build do
-  license "https://raw.githubusercontent.com/oetiker/rrdtool-1.x/master/COPYRIGHT"
+  ship_license "https://raw.githubusercontent.com/oetiker/rrdtool-1.x/master/COPYRIGHT"
   
   if Ohai['platform_family'] == 'debian'
     command "curl -O http://dd-agent.s3.amazonaws.com/python-rrdtool/deb/#{Ohai['kernel']['machine']}/rrdtool.so", :cwd => "#{install_dir}/embedded/lib/python2.7/"

--- a/config/software/python-rrdtool.rb
+++ b/config/software/python-rrdtool.rb
@@ -5,13 +5,13 @@ dependency "python"
 build do
   ship_license "https://raw.githubusercontent.com/oetiker/rrdtool-1.x/master/COPYRIGHT"
   
-  if Ohai['platform_family'] == 'debian'
-    command "curl -O http://dd-agent.s3.amazonaws.com/python-rrdtool/deb/#{Ohai['kernel']['machine']}/rrdtool.so", :cwd => "#{install_dir}/embedded/lib/python2.7/"
-  elsif Ohai['platform_family'] == 'rhel'
+  if ohai['platform_family'] == 'debian'
+    command "curl -O http://dd-agent.s3.amazonaws.com/python-rrdtool/deb/#{ohai['kernel']['machine']}/rrdtool.so", :cwd => "#{install_dir}/embedded/lib/python2.7/"
+  elsif ohai['platform_family'] == 'rhel'
    command "curl -O http://files.directadmin.com/services/9.0/ExtUtils-MakeMaker-6.31.tar.gz", :cwd => "/tmp/"
    command "tar xvzf ExtUtils-MakeMaker-6.31.tar.gz", :cwd => "/tmp/"
    command "perl Makefile.PL", :cwd => "/tmp/ExtUtils-MakeMaker-6.31"
-   if Ohai['kernel']['machine'] == 'i686'
+   if ohai['kernel']['machine'] == 'i686'
      command "curl -O http://cpansearch.perl.org/src/JHI/perl-5.8.0/thrdvar.h", :cwd => "/usr/lib/perl5/CORE/"
    end
    command "make", :cwd => "/tmp/ExtUtils-MakeMaker-6.31"

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -34,7 +34,7 @@ env = {
 }
 
 build do
-  license "PSFL"
+  ship_license "PSFL"
   command ["./configure",
            "--prefix=#{install_dir}/embedded",
            "--enable-shared",

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -41,7 +41,7 @@ build do
            "--with-dbmliborder="].join(" "), :env => env
   command "make", :env => env
   command "make install", :env => env
-  command "rm -rf #{install_dir}/embedded/lib/python2.7/test"
+  delete "#{install_dir}/embedded/lib/python2.7/test"
 
   # There exists no configure flag to tell Python to not compile readline support :(
   block do

--- a/config/software/pyvmomi.rb
+++ b/config/software/pyvmomi.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/vmware/pyvmomi/master/LICENSE.txt"
+  ship_license "https://raw.githubusercontent.com/vmware/pyvmomi/master/LICENSE.txt"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pyyaml.rb
+++ b/config/software/pyyaml.rb
@@ -6,6 +6,6 @@ dependency "pip"
 dependency "libyaml"
 
 build do
-  license "http://pyyaml.org/export/385/pyyaml/trunk/LICENSE"
+  ship_license "http://pyyaml.org/export/385/pyyaml/trunk/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/requests.rb
+++ b/config/software/requests.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/kennethreitz/requests/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/kennethreitz/requests/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/rsync.rb
+++ b/config/software/rsync.rb
@@ -26,7 +26,7 @@ source :url => "http://rsync.samba.org/ftp/rsync/src/rsync-3.0.9.tar.gz",
 relative_path "rsync-3.0.9"
 
 env =
-  case Ohai['platform']
+  case ohai['platform']
   when "solaris2"
       {
         "LDFLAGS" => "-R #{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",

--- a/config/software/ruby.rb
+++ b/config/software/ruby.rb
@@ -26,7 +26,7 @@ dependency "libyaml"
 dependency "libiconv"
 dependency "libffi"
 dependency "gdbm"
-dependency "libgcc" if Ohai['platform'] == "solaris2"
+dependency "libgcc" if ohai['platform'] == "solaris2"
 
 version("1.9.3-p484") { source md5: "8ac0dee72fe12d75c8b2d0ef5d0c2968" }
 version("1.9.3-p547") { source md5: "7531f9b1b35b16f3eb3d7bea786babfd" }
@@ -43,7 +43,7 @@ relative_path "ruby-#{version}"
 env = with_embedded_path()
 env = with_standard_compiler_flags(env)
 
-case Ohai['platform']
+case ohai['platform']
 when "mac_os_x"
   # -Qunused-arguments suppresses "argument unused during compilation"
   # warnings. These can be produced if you compile a program that doesn't
@@ -78,7 +78,7 @@ build do
                        "--disable-install-doc",
                        "--without-gmp"]
 
-  case Ohai['platform']
+  case ohai['platform']
   when "aix"
     patch :source => "ruby-aix-configure.patch", :plevel => 1
     patch :source => "ruby_aix_1_9_3_448_ssl_EAGAIN.patch", :plevel => 1
@@ -134,7 +134,7 @@ build do
   # The alternative would be to patch configure to remove all the pkg-config garbage entirely
   env.merge!({
     "PKG_CONFIG" => "/bin/true",
-  }) if Ohai['platform'] == "aix"
+  }) if ohai['platform'] == "aix"
 
   command configure_command.join(" "), :env => env
   command "#{make_binary} -j #{workers}", :env => env

--- a/config/software/server-jre.rb
+++ b/config/software/server-jre.rb
@@ -26,7 +26,7 @@ whitelist_file "jre/lib"
 whitelist_file "jre/plugin"
 whitelist_file "jre/bin/appletviewer"
 
-if Ohai['kernel']['machine'] =~ /x86_64/
+if ohai['kernel']['machine'] =~ /x86_64/
   # TODO: download x86 version on x86 machines
   source :url => "http://download.oracle.com/otn-pub/java/jdk/7u25-b15/server-jre-7u25-linux-x64.tar.gz",
          :md5 => "7164bd8619d731a2e8c01d0c60110f80",

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -26,6 +26,6 @@ source :url => "https://pypi.python.org/packages/source/s/setuptools/setuptools-
 relative_path "setuptools-#{version}"
 
 build do
-  license "PSFL"
+  ship_license "PSFL"
   command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
 end

--- a/config/software/simplejson.rb
+++ b/config/software/simplejson.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/simplejson/simplejson/master/LICENSE.txt"
+  ship_license "https://raw.githubusercontent.com/simplejson/simplejson/master/LICENSE.txt"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/snakebite.rb
+++ b/config/software/snakebite.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/spotify/snakebite/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/spotify/snakebite/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/spidermonkey.rb
+++ b/config/software/spidermonkey.rb
@@ -52,7 +52,7 @@ build do
           :env => env,
           :cwd => working_dir)
 
-  if Ohai['kernel']['machine'] =~ /x86_64/
+  if ohai['kernel']['machine'] =~ /x86_64/
     command "mv #{install_dir}/embedded/lib64/libjs.a #{install_dir}/embedded/lib"
     command "mv #{install_dir}/embedded/lib64/libjs.so #{install_dir}/embedded/lib"
   end

--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
+  ship_license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -1,6 +1,8 @@
 name "sysstat"
 default_version "11.1.3"
 
+dependency "tar"
+
 source :url => "http://perso.orange.fr/sebastien.godard/sysstat-#{version}.tar.xz",
        :md5 => "27385bcb6c1e585de8ba7cb25ac67aef"
 
@@ -13,7 +15,7 @@ env = {
 }
 
 build do
-  add_source "http://perso.orange.fr/sebastien.godard/sysstat-#{version}.tar.xz"
+  ship_source "http://perso.orange.fr/sebastien.godard/sysstat-#{version}.tar.xz"
   ship_license "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
   command(["./configure",
        "--prefix=#{install_dir}/embedded",

--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -1,8 +1,6 @@
 name "sysstat"
 default_version "11.1.3"
 
-dependency "tar"
-
 source :url => "http://perso.orange.fr/sebastien.godard/sysstat-#{version}.tar.xz",
        :md5 => "27385bcb6c1e585de8ba7cb25ac67aef"
 

--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -14,7 +14,7 @@ env = {
 
 build do
   add_source "http://perso.orange.fr/sebastien.godard/sysstat-#{version}.tar.xz"
-  license "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
+  ship_license "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
   command(["./configure",
        "--prefix=#{install_dir}/embedded",
        "--disable-nls"].join(" "),

--- a/config/software/tar.rb
+++ b/config/software/tar.rb
@@ -9,9 +9,12 @@ source :url => "http://ftp.gnu.org/gnu/tar/tar-#{version}.tar.gz",
 
 relative_path "#{name}-#{version}"
 build do
-    if Ohai['platform_family'] == 'rhel'
+    if ohai['platform_family'] == 'rhel'
+        delete "/bin/gtar /bin/tar"
         command "FORCE_UNSAFE_CONFIGURE=1 ./configure --prefix=/"
         command "make -j #{workers}"
         command "make install"
+        # Omnibus 4 uses gtar instead of tar so let's make a proper symlink
+        command "ln -sf /bin/tar /bin/gtar"
     end
 end

--- a/config/software/tornado.rb
+++ b/config/software/tornado.rb
@@ -7,6 +7,6 @@ dependency "pycurl"
 dependency "futures"
 
 build do
-  license "https://raw.githubusercontent.com/tornadoweb/tornado/master/LICENSE"
+  ship_license "https://raw.githubusercontent.com/tornadoweb/tornado/master/LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -40,7 +40,7 @@ configure_env =
   end
 
 build do
-  license "http://cgit.freedesktop.org/xorg/util/macros/plain/COPYING"
+  ship_license "http://cgit.freedesktop.org/xorg/util/macros/plain/COPYING"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -8,7 +8,7 @@ source :url => "http://xorg.freedesktop.org/releases/individual/util/util-macros
 relative_path "util-macros-#{version}"
 
 configure_env =
-  case Ohai['platform']
+  case ohai['platform']
   when "aix"
     {
       "CC" => "xlc -q64",

--- a/config/software/uuid.rb
+++ b/config/software/uuid.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  license "PSFL"
+  ship_license "PSFL"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -8,7 +8,7 @@ source :url => "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{v
 relative_path "xproto-#{version}"
 
 configure_env =
-  case Ohai['platform']
+  case ohai['platform']
   when "aix"
     {
       "CC" => "xlc -q64",

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -40,7 +40,7 @@ configure_env =
   end
 
 build do
-  license "http://cgit.freedesktop.org/xorg/proto/xproto/plain/COPYING"
+  ship_license "http://cgit.freedesktop.org/xorg/proto/xproto/plain/COPYING"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -38,7 +38,7 @@ env = with_standard_compiler_flags()
 env['CFLAGS'] << " -DNO_VIZ" if Ohai['platform'] == 'solaris2'
 
 build do
-  license "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"
+  ship_license "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}", :env => env
   command "make -j #{workers} install", :env => env

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -35,7 +35,7 @@ relative_path "zlib-#{version}"
 #env = with_embedded_path()
 env = with_standard_compiler_flags()
 # for some reason zlib needs this flag on solaris (cargocult warning?)
-env['CFLAGS'] << " -DNO_VIZ" if Ohai['platform'] == 'solaris2'
+env['CFLAGS'] << " -DNO_VIZ" if ohai['platform'] == 'solaris2'
 
 build do
   ship_license "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"


### PR DESCRIPTION
Made our software definition compatible with our fork of Omnibus-4. Nothing really smart in here, some functions have been renamed, some DSLs have been added to avoid using the `command` DSL too much and therefore make it easier to port our build across platforms (especially non Unix ones... aka Windows).