### PR TITLE
New cacert version with updated md5.

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -17,7 +17,11 @@
 name "cacerts"
 
 # Date of the file is in a comment at the start, or in the changelog
-default_version "2015.09.02"
+default_version "2015.10.28"
+
+version "2015.10.28" do
+  source md5: "6f41fb0f0c4b4695c2a6296892278141"
+end
 
 version "2015.09.02" do
   source md5: "3e0e6f302bd4f5b94040b8bcee0ffe15"


### PR DESCRIPTION
New version to the certificate at http://curl.haxx.se/ca/cacert.pem