### PR TITLE
[osx][qt] Fix openssl issue

### DIFF
--- a/config/software/qt.rb
+++ b/config/software/qt.rb
@@ -5,6 +5,7 @@ default_version "4.8"
 dependency "homebrew"
 
 build do
+  command "cd $( brew --prefix ) && git checkout a5112b"
   command "brew install qt"
   command "brew linkapps qt"
 end


### PR DESCRIPTION
Pin homebrew version so that a previous version of the qt bottle is
installed. Current versions cause an issue with the openssl libraries.

This is a temporary fix, in the long term we should try to get rid of the Qt dependency.