### PR TITLE
[openssl] Download source through plain HTTP

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,7 +24,7 @@ dependency "makedepend"
 
 
 default_version "1.0.1q"
-source url: "https://www.openssl.org/source/#{name}-#{version}.tar.gz",
+source url: "http://www.openssl.org/source/#{name}-#{version}.tar.gz",
        md5: "54538d0cdcb912f9bc2b36268388205e"
 
 relative_path "openssl-#{version}"


### PR DESCRIPTION
The version of OpenSSL that currently runs on our build containers
(~0.9.8) fails to complete the SSL handshake with www.openssl.org, so
let's keep using plain HTTP.

Fixes the builds.