### PR TITLE
[core][directory] Add scandir dependency

### DIFF
--- a/config/software/scandir.rb
+++ b/config/software/scandir.rb
@@ -1,0 +1,27 @@
+#
+# Copyright:: Copyright (c) 2013-2014 Chef Software, Inc.
+# License:: Apache License, Version 2.0
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name "scandir"
+default_version "1.2"
+
+dependency "python"
+dependency "pip"
+
+build do
+  ship_license "https://raw.githubusercontent.com/benhoyt/scandir/v1.2/LICENSE.txt"
+  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+end


### PR DESCRIPTION
Scandir provides us with much faster directory walking, and is now
folded into Python 3.5 as part of the standard lib. It avoids an
extraneous stat() on each file as the directory is walked.

More information can be found here: https://github.com/benhoyt/scandir#background