### PR TITLE
[curl][cacerts] Use our s3 bucket instead of the curl website

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -59,7 +59,7 @@ version "2014.01.28" do
   source md5: "5d108f8ab86afacc6663aafca8604dd3"
 end
 
-source url: "http://curl.haxx.se/ca/cacert.pem"
+source url: "http://s3.amazonaws.com/dd-agent-omnibus/cacert.pem"
 relative_path "cacerts-#{version}"
 
 build do

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -21,7 +21,7 @@ default_version "7.41.0"
 dependency "zlib"
 dependency "openssl"
 
-source :url => "http://curl.haxx.se/download/curl-#{version}.tar.gz",
+source :url => "http://s3.amazonaws.com/dd-agent-omnibus/curl-#{version}.tar.gz",
        :md5 => "7321a0a3012f8eede729b5a44ebef5bd"
 
 relative_path "curl-#{version}"


### PR DESCRIPTION
http://curl.haxx.se now redirects to https://... , and the https
website requires TLS, which is not compatible with the openssl version
that we run on our CentOS 5-based containers (and that ruby uses).

Switch to our s3 bucket as a temp workaround until we update openssl
and link ruby against it on our container image.