### PR TITLE
[python] Patch ctypes to avoid import failure on SELinux

### DIFF
--- a/config/patches/python/python-2.7.11-avoid-allocating-thunks-in-ctypes.patch
+++ b/config/patches/python/python-2.7.11-avoid-allocating-thunks-in-ctypes.patch
@@ -1,0 +1,14 @@
+--- Python-2.7.11/Lib/ctypes/__init__.py.orig   2016-03-09 16:29:58.221099618 +0000
++++ Python-2.7.11/Lib/ctypes/__init__.py    2016-03-09 16:33:36.971654184 +0000
+@@ -272,11 +272,6 @@
+     # _SimpleCData.c_char_p_from_param
+     POINTER(c_char).from_param = c_char_p.from_param
+     _pointer_type_cache[None] = c_void_p
+-    # XXX for whatever reasons, creating the first instance of a callback
+-    # function is needed for the unittests on Win64 to succeed.  This MAY
+-    # be a compiler bug, since the problem occurs only when _ctypes is
+-    # compiled with the MS SDK compiler.  Or an uninitialized variable?
+-    CFUNCTYPE(c_int)(lambda: None)
+
+ try:
+     from _ctypes import set_conversion_mode

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -47,6 +47,7 @@ python_configure.push("--with-dbmliborder=")
 
 build do
   ship_license "PSFL"
+  patch :source => 'python-2.7.11-avoid-allocating-thunks-in-ctypes.patch' if linux?
   command python_configure.join(" "), :env => env
   command "make -j #{workers}", :env => env
   command "make install", :env => env


### PR DESCRIPTION
On SELinux-enabled environments, an import of the `ctypes` module
raises a `MemoryError` and a subsequent segfault. To avoid this we
remove the faulty line that seem to have been there only for windows
64 bit.

A similar patch is present on some packaged Python versions provided
on some distros, see for instance on the Fedora python 2.7.3-4 pkg:
https://lists.fedoraproject.org/pipermail/scm-commits/2012-April/772613.html

This issue has shown up in the `5.7.0` Datadog Agent because of the newly-included `uptime` module that imports `ctypes` without catching `MemoryError`s (see https://github.com/Cairnarvon/uptime/blob/2f2e4f945182449c9589675c35b2d41060b09fbe/src/__init__.py#L16).

Should fix https://github.com/DataDog/dd-agent/issues/2327