### PR TITLE
[datadogpy][requests] Do not re-install `requests` with `datadogpy`

### DIFF
--- a/config/software/datadogpy.rb
+++ b/config/software/datadogpy.rb
@@ -6,5 +6,7 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/datadogpy/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" datadog==#{version}"
+  # We use `pip install` w/o the `-I` option here because we don't want pip to ignore the deps that have
+  # already been installed (for instance `requests`), as it could make pip potentially install a different version of the the dep
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" datadog==#{version}"
 end


### PR DESCRIPTION
Previously pip was set to ignore the packages that were already
installed, which led pip to install `requests` (one of datadogpy's
deps) with a different version than the one specified in `requests`'
software def.

To fix this, make pip consider already-installed packages.