### PR TITLE
[dependencies] Upgrade boto 2.36.0 -> 2.39.0

### DIFF
--- a/config/software/boto.rb
+++ b/config/software/boto.rb
@@ -1,5 +1,5 @@
 name "boto"
-default_version "2.36.0"
+default_version "2.39.0"
 dependency "python"
 dependency "pip"
 


### PR DESCRIPTION
There is a bug in boto 2.36.0 that is fixed in the 2.39.0 release: boto/boto#3399