### PR TITLE
[pyyaml][license] Use our s3 bucket instead of pyyaml.org

### DIFF
--- a/config/software/pyyaml.rb
+++ b/config/software/pyyaml.rb
@@ -6,6 +6,6 @@ dependency "pip"
 dependency "libyaml"
 
 build do
-  ship_license "http://pyyaml.org/export/385/pyyaml/trunk/LICENSE"
+  ship_license "http://dd-agent-omnibus.s3.amazonaws.com/pyyaml-LICENSE"
   command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end


### PR DESCRIPTION
pyyaml.org has DNS resolution issues. Use a copy of the license hosted
on our s3 bucket instead.