### PR TITLE
[libyaml] Host on our s3 bucket

### DIFF
--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -18,7 +18,7 @@
 name "libyaml"
 default_version '0.1.6'
 
-source :url => "http://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz",
+source :url => "http://dd-agent-omnibus.s3.amazonaws.com/yaml-#{version}.tar.gz",
        :md5 => '5fe00cda18ca5daeb43762b80c38e06e'
 
 relative_path "yaml-#{version}"


### PR DESCRIPTION
pyyaml.org is down, host the src pkg on our s3 bucket instead