### PR TITLE
[gohai] Properly pin gopsutil version

### DIFF
--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -16,11 +16,12 @@ end
 build do
    ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
    ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
+   # Go get gohai
+   command "#{gobin} get -d -u github.com/DataDog/gohai", :env => env
    # Checkout gohai's deps
    command "#{gobin} get -u github.com/shirou/gopsutil", :env => env
    command "git checkout v2.0.0", :env => env, :cwd => "/var/cache/omnibus/src/datadog-gohai/src/github.com/shirou/gopsutil"
    # Checkout and build gohai
-   command "#{gobin} get -d -u github.com/DataDog/gohai", :env => env
    command "git checkout #{version} && git pull", :env => env, :cwd => "/var/cache/omnibus/src/datadog-gohai/src/github.com/DataDog/gohai"
    command "cd $GOPATH/src/github.com/DataDog/gohai && #{gobin} run make.go '#{gobin}' && mv gohai #{install_dir}/bin/gohai", :env => env
 end


### PR DESCRIPTION
Using `go get -u` on gohai checkouts the master branch of gopsutil.

To pin it properly, checkout version `v2.0.0` of gopsutil after
`go get`ting gohai.