### PR TITLE
Bump docker-py to 1.8.1 for network features

### DIFF
--- a/config/software/docker-py.rb
+++ b/config/software/docker-py.rb
@@ -1,5 +1,5 @@
 name "docker-py"
-default_version "1.3.1"
+default_version "1.8.1"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Docker recently introduced networks, docker-py 1.3.1 doesn't support them, let's upgrade to the most recent version.

tested successfully

related: https://github.com/DataDog/dd-agent/pull/2556