### PR TITLE
Add definition for python-binary-memcached pip package

### DIFF
--- a/config/software/python-binary-memcached.rb
+++ b/config/software/python-binary-memcached.rb
@@ -1,0 +1,9 @@
+name "python-binary-memcached"
+default_version "0.24.6"
+
+dependency "python"
+
+build do
+  ship_license "MIT"
+  command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}"
+end


### PR DESCRIPTION
This is to support the follow PRs:
- DataDog/dd-agent#2570: Switch to python-binary-memcached & support SASL authentication
- DataDog/dd-agent-omnibus#80: Use python-binary-memcached instead of python-memcached
