### PR TITLE
Revert "Upgrade kafka-python to 1.2.5"

### DIFF
--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -1,5 +1,5 @@
 name "kafka-python"
-default_version "1.2.5"
+default_version "0.9.3"
 
 
 dependency "python"


### PR DESCRIPTION
Reverts DataDog/omnibus-software#66

Let's revert the upgrade until the `kafka_consumer` check is changed accordingly (see https://github.com/DataDog/dd-agent/pull/2709)