### PR TITLE
[f5check] Added dependency information for net-snmp-5.7.3 and easysnmp.

### DIFF
--- a/config/software/easysnmp.rb
+++ b/config/software/easysnmp.rb
@@ -1,0 +1,11 @@
+name "easysnmp"
+default_version "0.2.4"
+
+dependency "libnetsnmp"
+dependency "python"
+dependency "pip"
+
+build do
+  license "https://github.com/fgimian/easysnmp/blob/master/LICENSE"
+  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+end

--- a/config/software/libnetsnmp.rb
+++ b/config/software/libnetsnmp.rb
@@ -1,0 +1,22 @@
+name "libnetsnmp"
+default_version "5.7.3"
+
+source :url => "https://sourceforge.net/projects/net-snmp/files/net-snmp/5.7.3/net-snmp-5.7.3.tar.gz/download",
+       md5: "d4a3459e1577d0efa8d96ca70a885e53"
+
+relative_path 'libnetsnmp'
+
+env = {
+  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
+  "LD_RUN_PATH" => "#{install_dir}/embedded/lib"
+}
+
+build do
+  command(["./configure",
+       "--prefix=#{install_dir}/embedded",
+       "--disable-nls"].join(" "),
+    :env => env)
+  command "make -j #{workers}", :env => {"LD_RUN_PATH" => "#{install_dir}/embedded/lib"}
+  command "sudo make install"
+end


### PR DESCRIPTION
Added dependency easysnmp and net-snmp for F5 BIGIP metric check.

https://github.com/DataDog/dd-agent/issues/2742
https://github.com/DataDog/dd-agent/pull/2743
