### PR TITLE
[kafka-python] bumping lib version to 1.2.5.

### DIFF
--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -1,5 +1,5 @@
 name "kafka-python"
-default_version "0.9.3"
+default_version "1.2.5"
 
 
 dependency "python"


### PR DESCRIPTION
Version bump for kafka. See https://github.com/DataDog/dd-agent/pull/2709.

