### PR TITLE
Pin to `urllib` to `1.16` + upgrade `requests` to `2.6.2`

### DIFF
--- a/config/software/python-etcd.rb
+++ b/config/software/python-etcd.rb
@@ -6,5 +6,6 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/jplana/python-etcd/master/LICENSE.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" python-etcd==#{version}"
+  # pin the `urllib3` subdependency to 1.16 to avoid memory bloat of 1.17 (see commit for details)
+  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" urllib3==1.16 python-etcd==#{version}"
 end

--- a/config/software/requests.rb
+++ b/config/software/requests.rb
@@ -1,5 +1,5 @@
 name "requests"
-default_version "2.6.0"
+default_version "2.6.2"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
### Motivation

The RSS of the agent processes increased by  ~5MB per python process because of an upgrade of `urllib3` to `1.17`.

### What this does
1. Pin `urllib3` to `1.16`
The nightly Agent recently picked up version `1.17` of `urllib3` (dep of `python-etcd`), which introduces changes to its deps and the way it loads its deps for its pyopenssl contrib module (see https://github.com/shazow/urllib3/pull/930) . Unfortunately these changes cause a lot of new imports (`OpenSSL`, `idna`, `cryptography`) which lead to the RSS increases of the python processes. AFAIK we do not need the changes brought by the `1.17` upgrade in `python-etcd`, so let's pin `urllib3` to `1.16`.
NB: the `urllib3` module is loaded in all of the Agent's processes because of some service-discovery-related modules (`config.py` imports stuff from `utils/service_discovery`, which imports `etcd`)

2. Not directly related to the fix, but upgrading `requests` to `2.6.1` updates the way the modules vendored with `requests` in `requests.packages.*` are imported (see [this PR](https://github.com/kennethreitz/requests/pull/2556)). In particular this allows `requests` to import its own `requests.packages.urllib3` and not try to import the `urllib3` module directly.
We upgrade to `2.6.2` directly because it fixes a regression introduced by `2.6.1`.
See https://github.com/kennethreitz/requests/blob/v2.6.2/HISTORY.rst


### More details on the `urllib3` behavior change
Here's what I understand about what's happening on `urllib3`'s side:

- https://github.com/shazow/urllib3/pull/930 changes `urllib`'s deps in version `1.17`, and when importing the [pyopenssl.py file](https://github.com/shazow/urllib3/blob/1.17/urllib3/contrib/pyopenssl.py) the module in turn imports `OpenSSL`, `cryptography` and `idna`.
- in `1.16`, this doesn't happen because [pyopenssl.py](https://github.com/shazow/urllib3/blob/1.16/urllib3/contrib/pyopenssl.py#L49) tries (and fails) to import the `ndg` module (because it's not shipped with the Agent), so the whole import of `pyopenssl` fails silently.

### Review highlights

I've also upgraded `requests` because the direct `urllib3` import from it was extremely counter-intuitive and sounds like a bug since requests should import from its own vendored modules. The upgrade to `2.6.2` should be painless but it may be unsafe to upgrade it now, we may want to wait for the `5.9.0` release to be out before doing this.

### Todo
- The upgrade of `urllib3` was completely silent. In the future we may want to freeze all the python deps of the Agent in a `requirements.txt` file (that would list the deps and their deps in the same fashion as a `Gemfile.lock` file).
- in the future, could the `pyopenssl` module of `urllib3` be of any use to the Agent?