### PR TITLE
[pip deps] Remove `-I` option

### DIFF
--- a/config/software/adodbapi.rb
+++ b/config/software/adodbapi.rb
@@ -7,5 +7,5 @@ dependency "pyro4"
 
 build do
   ship_license "LGPLv2"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/beautifulsoup4.rb
+++ b/config/software/beautifulsoup4.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "http://bazaar.launchpad.net/~leonardr/beautifulsoup/bs4/download/head:/copying-20110228012957-7ptf6yxua0sj3vhn-1/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/boto.rb
+++ b/config/software/boto.rb
@@ -5,5 +5,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/boto/boto/develop/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/cython.rb
+++ b/config/software/cython.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/cython/cython/master/LICENSE.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--no-cython-compile\" cython==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--no-cython-compile\" cython==#{version}"
 end

--- a/config/software/datadogpy.rb
+++ b/config/software/datadogpy.rb
@@ -6,7 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/datadogpy/master/LICENSE"
-  # We use `pip install` w/o the `-I` option here because we don't want pip to ignore the deps that have
-  # already been installed (for instance `requests`), as it could make pip potentially install a different version of the the dep
   command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" datadog==#{version}"
 end

--- a/config/software/dnspython.rb
+++ b/config/software/dnspython.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/rthalley/dnspython/v1.12.0/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" dnspython==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" dnspython==#{version}"
 end

--- a/config/software/docker-py.rb
+++ b/config/software/docker-py.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "Apachev2"
-  command "#{install_dir}/embedded/bin/pip install --force-reinstall -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}", :cwd => "/tmp"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}", :cwd => "/tmp"
 end

--- a/config/software/futures.rb
+++ b/config/software/futures.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://pythonfutures.googlecode.com/hg/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/google-apputils.rb
+++ b/config/software/google-apputils.rb
@@ -12,5 +12,5 @@ dependency "python"
 dependency "pip"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install #{name}==#{version}"
 end

--- a/config/software/httplib2.rb
+++ b/config/software/httplib2.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/jcgregorio/httplib2/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -7,5 +7,5 @@ dependency "pip"
 
 build do
   ship_license "Apachev2"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/kazoo.rb
+++ b/config/software/kazoo.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "Apachev2"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/meld3.rb
+++ b/config/software/meld3.rb
@@ -12,5 +12,5 @@ dependency "python"
 dependency "pip"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install #{name}==#{version}"
 end

--- a/config/software/ntplib.rb
+++ b/config/software/ntplib.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "MIT"
-  command "#{install_dir}/embedded/bin/pip install --force-reinstall -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}", :cwd => "/tmp"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}", :cwd => "/tmp"
 end

--- a/config/software/paramiko.rb
+++ b/config/software/paramiko.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/paramiko/paramiko/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pg8000.rb
+++ b/config/software/pg8000.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/mfenniak/pg8000/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/psutil.rb
+++ b/config/software/psutil.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/psycopg2.rb
+++ b/config/software/psycopg2.rb
@@ -11,5 +11,5 @@ env = {
 
 build do
   ship_license "https://raw.githubusercontent.com/psycopg/psycopg2/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}", :env => env
+  command "#{install_dir}/embedded/bin/pip install #{name}==#{version}", :env => env
 end

--- a/config/software/pycrypto.rb
+++ b/config/software/pycrypto.rb
@@ -5,5 +5,5 @@ dependency "python"
 dependency "pip"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install #{name}==#{version}"
 end

--- a/config/software/pycurl.rb
+++ b/config/software/pycurl.rb
@@ -13,5 +13,5 @@ build do
     "PATH" => "/#{install_dir}/embedded/bin:#{ENV['PATH']}",
     "ARCHFLAGS" => "-arch x86_64"
   }
-  command "#{install_dir}/embedded/bin/pip install -I #{name}==#{version}", :env => build_env
+  command "#{install_dir}/embedded/bin/pip install #{name}==#{version}", :env => build_env
 end

--- a/config/software/pygments.rb
+++ b/config/software/pygments.rb
@@ -21,5 +21,5 @@ default_version "1.6"
 dependency "pip"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --build #{project_dir} #{name}==#{version}"
 end

--- a/config/software/pymongo.rb
+++ b/config/software/pymongo.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "Apachev2"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pymysql.rb
+++ b/config/software/pymysql.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/PyMySQL/PyMySQL/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -14,5 +14,5 @@ build do
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
     "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include/"
   }
-  command "#{install_dir}/embedded/bin/pip install -I pyOpenSSL==#{version}", :env => build_env
+  command "#{install_dir}/embedded/bin/pip install pyOpenSSL==#{version}", :env => build_env
 end

--- a/config/software/pyro4.rb
+++ b/config/software/pyro4.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/irmen/Pyro4/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" Pyro4==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" Pyro4==#{version}"
 end

--- a/config/software/pysnmp-mibs.rb
+++ b/config/software/pysnmp-mibs.rb
@@ -6,6 +6,6 @@ dependency "pip"
 
 build do
   ship_license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end
 

--- a/config/software/python-consul.rb
+++ b/config/software/python-consul.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/cablehead/python-consul/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" python-consul==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" python-consul==#{version}"
 end

--- a/config/software/python-etcd.rb
+++ b/config/software/python-etcd.rb
@@ -7,5 +7,5 @@ dependency "pip"
 build do
   ship_license "https://raw.githubusercontent.com/jplana/python-etcd/master/LICENSE.txt"
   # pin the `urllib3` subdependency to 1.16 to avoid memory bloat of 1.17 (see commit for details)
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" urllib3==1.16 python-etcd==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" urllib3==1.16 python-etcd==#{version}"
 end

--- a/config/software/python-gearman.rb
+++ b/config/software/python-gearman.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/Yelp/python-gearman/master/LICENSE.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" gearman==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" gearman==#{version}"
 end

--- a/config/software/python-memcached.rb
+++ b/config/software/python-memcached.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "PSFL"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/python-readline.rb
+++ b/config/software/python-readline.rb
@@ -11,5 +11,5 @@ build do
       "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
       "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include/"
   }
-  command "#{install_dir}/embedded/bin/pip install -I readline==#{version}", :env => build_env
+  command "#{install_dir}/embedded/bin/pip install readline==#{version}", :env => build_env
 end

--- a/config/software/python-redis.rb
+++ b/config/software/python-redis.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/andymccurdy/redis-py/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" redis==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" redis==#{version}"
 end

--- a/config/software/pyvmomi.rb
+++ b/config/software/pyvmomi.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/vmware/pyvmomi/master/LICENSE.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/pyyaml.rb
+++ b/config/software/pyyaml.rb
@@ -7,5 +7,5 @@ dependency "libyaml"
 
 build do
   ship_license "http://dd-agent-omnibus.s3.amazonaws.com/pyyaml-LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/requests.rb
+++ b/config/software/requests.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/kennethreitz/requests/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/scandir.rb
+++ b/config/software/scandir.rb
@@ -23,5 +23,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/benhoyt/scandir/v1.2/LICENSE.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/simplejson.rb
+++ b/config/software/simplejson.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/simplejson/simplejson/master/LICENSE.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/snakebite.rb
+++ b/config/software/snakebite.rb
@@ -7,5 +7,5 @@ dependency "google-apputils"
 
 build do
   ship_license "https://raw.githubusercontent.com/spotify/snakebite/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/sphinx.rb
+++ b/config/software/sphinx.rb
@@ -22,5 +22,5 @@ dependency "pip"
 dependency "pygments"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I --build #{project_dir} #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --build #{project_dir} #{name}==#{version}"
 end

--- a/config/software/superlance.rb
+++ b/config/software/superlance.rb
@@ -5,5 +5,5 @@ dependency "python"
 dependency "pip"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end


### PR DESCRIPTION
The option makes pip ignore the pip pkgs that are already installed.

Removing it ensures that pip never installs the same package twice with
different versions (in which case we can't reliably predict which
version will actually be loaded by python).

This would happen for `requests`.

NB: we still don't fully guarantee that the requested version of a pip
package will be the one that's in the final package. For instance in
this (made-up) scenario:
1. install requests 2.5.0
2. install docker-py 1.8.1 (which requires requests >2.5.2)

The install of `docker-py` would remove the existing requests and
replace it with a higher version of requests, so the final package would
end up including requests 2.5.3 for instance.

We still need some after-the-fact checks to ensure that we are indeed
packaging the right versions of the pip deps we've pinned. These checks
are currently done in our internal `dd-agent-testing` job.