### PR TITLE
Bump kafka-python to 1.3.1

### DIFF
--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -1,5 +1,5 @@
 name "kafka-python"
-default_version "1.2.5"
+default_version "1.3.1"
 
 
 dependency "python"


### PR DESCRIPTION
There's a number of bug fixes and issues since the 1.2.5 release.

Details in https://github.com/DataDog/dd-agent/pull/2863
