### PR TITLE
[pip] Upgrade to 8.1.2

### DIFF
--- a/config/software/pip.rb
+++ b/config/software/pip.rb
@@ -17,12 +17,12 @@
 
 name "pip"
 
-default_version "6.1.1"
+default_version "8.1.2"
 
 dependency "setuptools"
 
-source :url => "https://pypi.python.org/packages/source/p/pip/pip-#{version}.tar.gz",
-       :md5 => '6b19e0a934d982a5a4b798e957cb6d45',
+source :url => "https://github.com/pypa/pip/archive/#{version}.tar.gz",
+       :sha256 => '8dae1fb72e29c2b6ff6ed267861179216bf98d3bda6d30e527dbed0db5ac7e1d',
        :extract => :seven_zip
 
 relative_path "pip-#{version}"

--- a/config/software/pyro4.rb
+++ b/config/software/pyro4.rb
@@ -1,5 +1,5 @@
 name "pyro4"
-default_version "4.35"
+default_version "4.36"
 
 dependency "python"
 dependency "pip"

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -16,10 +16,9 @@
 #
 
 name "setuptools"
-default_version "0.7.7"
+default_version "28.3.0"
 
 dependency "python"
-
 
 relative_path "setuptools-#{version}"
 
@@ -32,10 +31,11 @@ if ohai['platform'] == 'windows'
     command "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\" ez_setup.py "
   end
 else
-  source :url => "https://pypi.python.org/packages/source/s/setuptools/setuptools-#{version}.tar.gz",
-         :md5 => '0d7bc0e1a34b70a97e706ef74aa7f37f'
+  source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
+         :sha256 => '726d5247151b1be1fcc6b64bdb22df029364a75a4856a464ad88be65d285ab46'
   build do
     ship_license "PSFL"
+    command "#{install_dir}/embedded/bin/python bootstrap.py"
     command "#{install_dir}/embedded/bin/python setup.py install --prefix=#{install_dir}/embedded"
   end
 end

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -16,7 +16,7 @@
 #
 
 name "setuptools"
-default_version "28.3.0"
+default_version "28.8.0"
 
 dependency "python"
 
@@ -32,7 +32,8 @@ if ohai['platform'] == 'windows'
   end
 else
   source :url => "https://github.com/pypa/setuptools/archive/v#{version}.tar.gz",
-         :sha256 => '726d5247151b1be1fcc6b64bdb22df029364a75a4856a464ad88be65d285ab46'
+         :sha256 => 'd3b2c63a5cb6816ace0883bc3f6aca9e7890c61d80ac0d608a183f85825a7cc0'
+
   build do
     ship_license "PSFL"
     command "#{install_dir}/embedded/bin/python bootstrap.py"


### PR DESCRIPTION
Also requires bump on pyro4 version and setuptools.

Supersedes #60

Motivation:

> Allows users to install wheels on Windows more easily.

Note: Builds w/o errors on deb-x64
