### PR TITLE
compiles python with O2 rather than O3

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -32,7 +32,7 @@ if ohai['platform'] != 'windows'
   relative_path "Python-#{version}"
 
   env = {
-    "CFLAGS" => "-I#{install_dir}/embedded/include -O3 -g -pipe",
+    "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -g -pipe",
     "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib"
   }
 


### PR DESCRIPTION
This is a change I've wanted to make for a while, and figured this was the best time to do it.

Python is currently compiled with O3. Most OS's compile it with O2. There's no reason to optimize more than any of the OS's we're targeting.

There's a bunch of reasons why they use O2 instead of O3. First, O3 is slightly buggier than O2. I don't think it's caused any bugs in our code, however it makes it harder to track down intransigent bugs because they could be caused by the compiler optimization. Additionally, because it's biggest feature is the inlining of functions, it means that the package itself will be larger. It also ensure that we will have higher memory usage (something we should avoid).

I don't think that we need the additional optimizations, especially when they can introduce bugs and probably aren't improving our performance. For more information, [the Gentoo Wiki has a pretty good page on this](https://wiki.gentoo.org/wiki/GCC_optimization#-O).