### PR TITLE
[ci] Use `datadog-5.5.0` branch of `omnibus-ruby` in CI/dev envs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,7 +2,7 @@ source 'https://rubygems.org'
 gemspec
 
 group :development, :test do
-  gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: "datadog-5.0.0"
+  gem 'omnibus', git: 'git://github.com/datadog/omnibus-ruby.git', branch: "datadog-5.5.0"
   gem 'rake'
   gem 'highline'
 end


### PR DESCRIPTION
That's the branch we use by default everywhere else