### PR TITLE
[windows] fix definitions broken by pip 8.1.2

### DIFF
--- a/config/software/boto.rb
+++ b/config/software/boto.rb
@@ -5,5 +5,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/boto/boto/develop/LICENSE"
-  pip "install --install-option=\"--install-scripts='#{windows_safe_path(install_dir)}/bin'\" #{name}==#{version}"
+  pip "install #{name}==#{version}"
 end

--- a/config/software/pywin32.rb
+++ b/config/software/pywin32.rb
@@ -9,7 +9,7 @@ build do
     relative_path "pywin32-#{version}"
     # Switch on the architecture
     pip "install pypiwin32==#{version} "\
-             "--install-option=\"--prefix=#{windows_safe_path(install_dir)}\\embedded\""
+        "--prefix=#{windows_safe_path(install_dir)}/embedded"
     # pywintypes is patched, it doesn't work on Python > 2.7 otherwise
     # Since we don't install it from source, we can't use the patch option of omnibus
     # Here is a manual patch, using the same options as omnibus


### PR DESCRIPTION
pywin32: use `--prefix` option instead of the equivalent
`--install-option="--prefix='/blabla'"`, which can be used with wheels
and does not require a full rebuild of the lib.

boto: remove the --install-scripts option (doesn't work anymore). We
seem to be only importing boto, not using its command line utility.