### PR TITLE
Upgrade docker-py version to 1.10.6

### DIFF
--- a/config/software/docker-py.rb
+++ b/config/software/docker-py.rb
@@ -1,5 +1,5 @@
 name "docker-py"
-default_version "1.8.1"
+default_version "1.10.6"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
This is needed to follow the required version in the testing env.

Ref: https://github.com/DataDog/dd-agent/pull/3108