### PR TITLE
[guidata] new source

### DIFF
--- a/config/software/guidata.rb
+++ b/config/software/guidata.rb
@@ -4,8 +4,8 @@ default_version "1.6.1"
 
 dependency "pyside"
 
-source :url => "https://guidata.googlecode.com/files/guidata-#{version}.zip",
-       :md5 => "47d625f998b5092ba797c8657979aa94"
+source :url => "https://github.com/PierreRaybaut/guidata/archive/v#{version}.zip",
+       :md5 => "6827b98db4aca3ca50a7efa419367633"
 
 relative_path "guidata-#{version}"
 


### PR DESCRIPTION
Guidata was hosted on Google Code, which is now dead for real.
This commit switches the source to Github. The md5 changes because the
previous zip was slightly compressed (and was not shipping the tests for
instance), whereas this one contains the entire source code (because
it's automcatically generated by Github).