### PR TITLE
Return of always_build option

### DIFF
--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,6 +1,8 @@
 name "datadog-gohai"
 default_version "last-stable"
 
+always_build true
+
 env = {
   "GOPATH" => "#{Omnibus::Config.cache_dir}/src/#{name}",
 }

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,7 +1,7 @@
 name "datadog-gohai"
 default_version "last-stable"
 
-always_build true
+source github: "DataDog/gohai"
 
 env = {
   "GOPATH" => "#{Omnibus::Config.cache_dir}/src/#{name}",
@@ -19,14 +19,9 @@ end
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
-  # Go get gohai
-  command "#{gobin} get -d -u github.com/DataDog/gohai", :env => env
-  # Checkout gohai's deps
-  command "#{gobin} get -u github.com/shirou/gopsutil", :env => env
-  command "git checkout v2.0.0", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/shirou/gopsutil"
-  command "#{gobin} get -u github.com/cihub/seelog", :env => env
-  command "git checkout v2.6", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/cihub/seelog"
+  # dep manager
+  command "#{gobin} get github.com/Masterminds/glide", env: env
   # Checkout and build gohai
-  command "git checkout #{version} && git pull", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/DataDog/gohai"
-  command "cd #{env['GOPATH']}/src/github.com/DataDog/gohai && #{gobin} run make.go #{gobin} && mv gohai #{install_dir}/bin/gohai", :env => env
+  command "#{Omnibus::Config.cache_dir}/src/#{name}/bin/glide install", env: env
+  command "#{gobin} run make.go && mv datadog-gohai #{install_dir}/bin/gohai", env: env
 end

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -1,6 +1,8 @@
 name "datadog-metro"
 default_version "last-stable"
 
+always_build true
+
 env = {
   "GOROOT" => "/usr/local/go",
   "GOPATH" => "/var/cache/omnibus/src/datadog-metro",


### PR DESCRIPTION
Use it for datadog-metro and datadog-gohai.
Also complete change of the gohai build process, because we now use `glide` for Go dep management. This only works when using the `master` branch of gohai for now, b/c the glide changes are not yet on `last-stable`.