### PR TITLE
[Windows] add registry as a dependency for gohai checks.  Required for

### DIFF
--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -26,6 +26,10 @@ build do
   command "git checkout v2.0.0", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/shirou/gopsutil"
   command "#{gobin} get -u github.com/cihub/seelog", :env => env
   command "git checkout v2.6", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/cihub/seelog"
+  # Windows depends on the registry, go get that.
+  if ohai["platform"] == "windows"
+    command "#{gobin} get golang.org/x/sys/windows/registry", :env => env
+  end
   # Checkout and build gohai
   command "git checkout #{version} && git pull", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/DataDog/gohai"
   command "cd #{env['GOPATH']}/src/github.com/DataDog/gohai && #{gobin} run make.go #{gobin} && mv gohai #{install_dir}/bin/gohai", :env => env


### PR DESCRIPTION
https://github.com/DataDog/gohai/pull/39, which changes gohai from running
wmic commands