### PR TITLE
[pysnmp] break omnibus-pip circular dependency.

### DIFF
--- a/config/software/pysnmp-mibs.rb
+++ b/config/software/pysnmp-mibs.rb
@@ -3,6 +3,7 @@ default_version "0.1.4"
 
 dependency "python"
 dependency "pip"
+dependency "pysnmp"
 
 build do
   ship_license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"

--- a/config/software/pysnmp.rb
+++ b/config/software/pysnmp.rb
@@ -3,7 +3,6 @@ default_version "4.2.5"
 
 dependency "python"
 dependency "pip"
-dependency "pysnmp-mibs"
 dependency "pyasn1"
 
 build do


### PR DESCRIPTION
### Description

Break the existing circular dependency (omnibus-to-pip-to-omnibus) revolving around pysnmp. This was creating inconsistencies.
