### PR TITLE
[cryptography] depends on pyasn1.

### DIFF
--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -6,6 +6,7 @@ dependency "pip"
 
 dependency "libffi" # indirectly through the `cffi` python lib cryptography depends on
 dependency "openssl"
+dependency "pyasn1"
 
 build do
   ship_license "https://github.com/pyca/cryptography/blob/master/LICENSE.APACHE"


### PR DESCRIPTION
```
Metadata-Version: 1.1
Name: cryptography
Version: 1.7.2
Summary: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
Home-page: https://github.com/pyca/cryptography
Author: The cryptography developers
Author-email: cryptography-dev@python.org
License: BSD or Apache License, Version 2.0
Location: /opt/datadog-agent/embedded/lib/python2.7/site-packages
Requires: idna, pyasn1, six, setuptools, enum34, ipaddress, cffi
Entry-points:
  [cryptography.backends]
  openssl = cryptography.hazmat.backends.openssl:backend
```

It's bringing in `pyasn1` as well, sorry I missed this one too. 