### PR TITLE
[cryptography] dependency missing in branch.

### DIFF
--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -1,0 +1,14 @@
+name "cryptography"
+default_version "1.7.1"
+
+dependency "python"
+dependency "pip"
+
+dependency "libffi" # indirectly through the `cffi` python lib cryptography depends on
+dependency "openssl"
+dependency "pyasn1"
+
+build do
+  ship_license "https://github.com/pyca/cryptography/blob/master/LICENSE.APACHE"
+  pip "install cryptography==#{version}"
+end

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -4,6 +4,7 @@ default_version "0.14"
 dependency "openssl"
 dependency "python"
 dependency "pip"
+dependency "cryptography"
 dependency "libffi"
 
 build do


### PR DESCRIPTION
```
Metadata-Version: 1.1
Name: pyOpenSSL
Version: 0.14
Summary: Python wrapper module around the OpenSSL library
Home-page: https://github.com/pyca/pyopenssl
Author: Jean-Paul Calderone
Author-email: exarkun@twistedmatrix.com
License: APL2
Location: /opt/datadog-agent/embedded/lib/python2.7/site-packages
Requires: cryptography, six
```
```
Metadata-Version: 1.1
Name: cryptography
Version: 1.7.2
Summary: cryptography is a package which provides cryptographic recipes and primitives to Python developers.
Home-page: https://github.com/pyca/cryptography
Author: The cryptography developers
Author-email: cryptography-dev@python.org
License: BSD or Apache License, Version 2.0
Location: /opt/datadog-agent/embedded/lib/python2.7/site-packages
Requires: idna, pyasn1, six, setuptools, enum34, ipaddress, cffi
Entry-points:
  [cryptography.backends]
  openssl = cryptography.hazmat.backends.openssl:backend
```

`pyopenssl` should depend explicitly on `cryptography` (fixed on master), and `cryptography` should depend on `pyasn1`.