### PR TITLE
[pip] remove -I switch from all calls.

### DIFF
--- a/config/software/pysnmp.rb
+++ b/config/software/pysnmp.rb
@@ -7,5 +7,5 @@ dependency "pyasn1"
 
 build do
   ship_license "https://gist.githubusercontent.com/remh/519324dc1b69f7488239/raw/2bbf2888194fef8ae75651e551b61f90cb49c482/pysnmp.license"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/tornado.rb
+++ b/config/software/tornado.rb
@@ -8,5 +8,5 @@ dependency "futures"
 
 build do
   ship_license "https://raw.githubusercontent.com/tornadoweb/tornado/master/LICENSE"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/uptime.rb
+++ b/config/software/uptime.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "https://raw.githubusercontent.com/Cairnarvon/uptime/master/COPYING.txt"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/uuid.rb
+++ b/config/software/uuid.rb
@@ -6,5 +6,5 @@ dependency "pip"
 
 build do
   ship_license "PSFL"
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/virtualenv.rb
+++ b/config/software/virtualenv.rb
@@ -5,5 +5,5 @@ dependency "python"
 dependency "pip"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/virtualenvwrapper.rb
+++ b/config/software/virtualenvwrapper.rb
@@ -6,5 +6,5 @@ dependency "pip"
 dependency "virtualenv"
 
 build do
-  command "#{install_dir}/embedded/bin/pip install -I --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
+  command "#{install_dir}/embedded/bin/pip install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end


### PR DESCRIPTION
Switch would ignore already installed deps, potentially upgrading certain packages. This broke `pysnmp`, for instance, by dragging along a new version of `pyasn1`. 

This should address that, and other potential dependency issues.