### PR TITLE
[requests] Downgrade to `2.11.1`

### DIFF
--- a/config/software/requests.rb
+++ b/config/software/requests.rb
@@ -1,5 +1,5 @@
 name "requests"
-default_version "2.13.0"
+default_version "2.11.1"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
For some reason `requests` v2.12.0 to 2.13.0 use ~10MB more memory
once they're imported, which totals 30MB for the 3 main agent processes
and that's not acceptable