### PR TITLE
[python] Add patch to fix ssl module mem leak

### DIFF
--- a/config/patches/python/python-2.7.13-fix-ssl-leak.patch
+++ b/config/patches/python/python-2.7.13-fix-ssl-leak.patch
@@ -1,12 +1,14 @@
 --- Python-2.7.13/Modules/_ssl.c
 +++ Python-2.7.13/Modules/_ssl.c
-@@ -1173,9 +1173,7 @@ _get_crl_dp(X509 *certificate) {
-
-   done:
-     Py_XDECREF(lst);
--#if OPENSSL_VERSION_NUMBER < 0x10001000L
--    sk_DIST_POINT_free(dps);
+@@ -1128,8 +1128,10 @@ _get_crl_dp(X509 *certificate) {
+ #if OPENSSL_VERSION_NUMBER >= 0x10001000L
+     /* Calls x509v3_cache_extensions and sets up crldp */
+     X509_check_ca(certificate);
 -#endif
-+    sk_DIST_POINT_pop_free(dps, DIST_POINT_free);
-     return res;
- }
++    dps = certificate->crldp;
++#else
+     dps = X509_get_ext_d2i(certificate, NID_crl_distribution_points, NULL, NULL);
++#endif
+
+     if (dps == NULL)
+         return Py_None;

--- a/config/patches/python/python-2.7.13-fix-ssl-leak.patch
+++ b/config/patches/python/python-2.7.13-fix-ssl-leak.patch
@@ -1,0 +1,12 @@
+--- Python-2.7.13/Modules/_ssl.c
++++ Python-2.7.13/Modules/_ssl.c
+@@ -1173,9 +1173,7 @@ _get_crl_dp(X509 *certificate) {
+
+   done:
+     Py_XDECREF(lst);
+-#if OPENSSL_VERSION_NUMBER < 0x10001000L
+-    sk_DIST_POINT_free(dps);
+-#endif
++    sk_DIST_POINT_pop_free(dps, DIST_POINT_free);
+     return res;
+ }

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -52,6 +52,7 @@ if ohai["platform"] != "windows"
     ship_license "PSFL"
     patch :source => "python-2.7.11-avoid-allocating-thunks-in-ctypes.patch" if linux?
     patch :source => "python-2.7.11-fix-platform-ubuntu.diff" if linux?
+    patch :source => "python-2.7.13-fix-ssl-leak.patch"
 
     command python_configure.join(" "), :env => env
     command "make -j #{workers}", :env => env


### PR DESCRIPTION
Fixes a regression in python `2.7.13` which causes a memory leak in the forwarder when SSL validation is enabled.

The memory leak was originally fixed in [[1]], but got re-introduced in https://github.com/python/cpython/commit/c2fc7c4f53069558b52d7a497fc195efebe8b4db#diff-e1cc5bf74055e388cda128367a814c8fR1104

The code snippet in [[1]] reproduces the mem leak on a vanilla `2.7.13` python.

More details on the 2 commits, which implement 2 different fixes. The last commit implements what I believe is a safer approach for us (since it basically reverts the problematic change).

I've tested both fixes against the current build of the agent and they both seem to work fine and fix the leak.

I'll submit the issue/patch upstream shortly

[1]:https://bugs.python.org/issue25569