### PR TITLE
[pyodbc] Add software definition

### DIFF
--- a/config/software/pyodbc.rb
+++ b/config/software/pyodbc.rb
@@ -1,0 +1,13 @@
+name "pyodbc"
+default_version "4.0.13"
+
+dependency "python"
+dependency "pip"
+# Requires additional dep on Linux: unixODBC
+
+build do
+  ship_license "https://raw.githubusercontent.com/mkleehammer/pyodbc/master/LICENSE.txt"
+  pip "install --install-option="\
+      "\"--install-scripts=#{windows_safe_path(install_dir)}/bin\" "\
+      "#{name}==#{version}"
+end


### PR DESCRIPTION
Binary wheels are provided on Windows/MacOS but not on Linux