### PR TITLE
[net-snmp][net-snmp-lib] fix OSX build + ipv6 support

### DIFF
--- a/config/software/net-snmp-lib.rb
+++ b/config/software/net-snmp-lib.rb
@@ -4,7 +4,7 @@ default_version "5.7.3"
 # This definition differs from `net-snmp` in that this one will only ship
 # libnetsnmp and not the rest of the package. Headers are also installed
 # but not shipped, so they're provided for building (if needed).
-
+#
 version "5.7.3" do
   source sha256: "12ef89613c7707dc96d13335f153c1921efc9d61d3708ef09f3fc4a7014fb4f0"
 end
@@ -26,6 +26,7 @@ build_env = {
 
 net_snmp_configure = ["./configure",
                       "--with-defaults",
+                      "--enable-ipv6",
                       "--with-ldflags=-L#{install_dir}/embedded/lib",
                       "--with-cflags=-I#{install_dir}/embedded/include",
                       "--with-zlib=#{install_dir}/embedded/lib",
@@ -33,9 +34,16 @@ net_snmp_configure = ["./configure",
                       "--disable-embedded-perl",
                       "--without-perl-modules",
                       "--enable-shared",
-                      "--enable-static"]
+                      "--disable-static"]
 build do
   ship_license "https://gist.githubusercontent.com/truthbk/219266c31f7d664c749dba525eb8a7b0/raw/82539d51d5b1e545e1ceb241b25f476956b636f9/net-snmp.license"
+
+  if mac_os_x?
+    copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin14.h"
+    copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin15.h"
+    copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin16.h"
+  end
+
   command net_snmp_configure.join(" "), :env => build_env
   command "make -j #{workers}", :env => build_env
 

--- a/config/software/net-snmp.rb
+++ b/config/software/net-snmp.rb
@@ -22,6 +22,7 @@ build_env = {
 
 net_snmp_configure = ["./configure",
                       "--with-defaults",
+                      "--enable-ipv6",
                       "--prefix=#{install_dir}/embedded",
                       "--with-ldflags=-L#{install_dir}/embedded/lib",
                       "--with-cflags=-I#{install_dir}/embedded/include",
@@ -30,9 +31,16 @@ net_snmp_configure = ["./configure",
                       "--disable-embedded-perl",
                       "--without-perl-modules",
                       "--enable-shared",
-                      "--enable-static"]
+                      "--disable-static"]
 build do
   ship_license "https://gist.githubusercontent.com/truthbk/219266c31f7d664c749dba525eb8a7b0/raw/82539d51d5b1e545e1ceb241b25f476956b636f9/net-snmp.license"
+
+  if mac_os_x?
+    copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin14.h"
+    copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin15.h"
+    copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin16.h"
+  end
+
   command net_snmp_configure.join(" "), :env => build_env
   command "make -j #{workers}", :env => build_env
   command "make install"


### PR DESCRIPTION
### Description

Fixes the OSX build after breaking it with the addition of the snmp check and its dependent `net-snmp-lib`.

Reported here: https://github.com/DataDog/datadog-agent/issues/187

--------------------------------------------------
/cc @masci 
