### PR TITLE
Bump kafka-python to 1.3.3

### DIFF
--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -1,5 +1,5 @@
 name "kafka-python"
-default_version "1.3.1"
+default_version "1.3.3"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Adds bugfixes and supports some new kafka protocol calls

See also https://github.com/DataDog/integrations-core/pull/272