### PR TITLE
[psycopg2] whitelist all internal deps

### DIFF
--- a/config/software/psycopg2.rb
+++ b/config/software/psycopg2.rb
@@ -8,6 +8,8 @@ env = {
   "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}",
 }
 
+whitelist_file 'psycopg2\/.libs'
+
 build do
   ship_license "https://raw.githubusercontent.com/psycopg/psycopg2/master/LICENSE"
   pip "install #{name}==#{version}", :env => env


### PR DESCRIPTION
As omnibus health check doesn't detect they're there. They're all in
/opt/datadog-agent/embedded/lib/python2.7/site-packages/psycopg2/.libs
but it doesn't seem to be part of the path where omnibus looks for
dependencies, that's why we have to whitelist them (with a regex because
we can only have one 'whitelist_file').