### PR TITLE
Bump boto version to 2.46.1

### DIFF
--- a/config/software/boto.rb
+++ b/config/software/boto.rb
@@ -1,5 +1,5 @@
 name "boto"
-default_version "2.39.0"
+default_version "2.46.1"
 dependency "python"
 dependency "pip"
 


### PR DESCRIPTION
AWS az "us-east-2" has been added in boto 2.43. We currently ship 2.39.
This bump boto to the latest version (2.46.1 right now)