### PR TITLE
[gohai] Fix build with old version of go (1.3)

### DIFF
--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -19,8 +19,6 @@ end
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
-  # Go get gohai
-  command "#{gobin} get -d -u github.com/DataDog/gohai", :env => env
   # Checkout gohai's deps
   command "#{gobin} get -u github.com/shirou/gopsutil", :env => env
   command "git checkout v2.0.0", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/shirou/gopsutil"
@@ -31,6 +29,7 @@ build do
     command "#{gobin} get golang.org/x/sys/windows/registry", :env => env
   end
   # Checkout and build gohai
+  command "#{gobin} get -d github.com/DataDog/gohai", :env => env # No need to pull latest from remote with `-u` here since the next command checks out and pulls latest
   command "git checkout #{version} && git pull", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/DataDog/gohai"
   command "cd #{env['GOPATH']}/src/github.com/DataDog/gohai && #{gobin} run make.go #{gobin} && mv gohai #{install_dir}/bin/gohai", :env => env
 end


### PR DESCRIPTION
Fixes the build (see https://circleci.com/gh/DataDog/docker-dd-agent-build-deb-x64/1839 for example).

For some reason, when the deps of gohai are not yet present
in the gopath, `go get`ting gohai fails by getting the latest version
of gopsutil, which is only compatible with go >= 1.8.0. This happens
even with the `go get -d` option, which is supposed to only download
the packages.

As a workaround, we `go get` gohai only once the deps are already
present and pinned to supported versions.

The whole software def is quite ugly, that'll improve once we can
start using `glide` (which is blocked on the upgrade of go, which
itself waits on the upgrade of the centos build image to centos 6)