### PR TITLE
[libxml2] bumping default version to 2.9.4.

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -16,7 +16,7 @@
 #
 
 name "libxml2"
-default_version "2.9.1"
+default_version "2.9.4"
 
 dependency "zlib"
 dependency "libiconv"
@@ -28,6 +28,10 @@ end
 
 version "2.9.1" do
   source md5: "9c0cfef285d5c4a5c80d00904ddab380"
+end
+
+version "2.9.4" do
+  source sha256: "ffb911191e509b966deb55de705387f14156e1a56b21824357cdf0053233633c"
 end
 
 source url: "ftp://xmlsoft.org/libxml2/libxml2-#{version}.tar.gz"


### PR DESCRIPTION
Fix for CVE-2013-0339 and CVE-2014-3660

### Testing
tested build process is fine, agent working fine 👍 