### PR TITLE
bump python-etcd to 0.4.5 to get auth support

### DIFF
--- a/config/software/python-etcd.rb
+++ b/config/software/python-etcd.rb
@@ -1,5 +1,5 @@
 name "python-etcd"
-default_version "0.4.2"
+default_version "0.4.5"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Changelog audited and no breaking API changes for the methods we use

Dependency for https://github.com/DataDog/dd-agent/pull/3357