### PR TITLE
update cacert checksum to latest release

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -21,7 +21,7 @@ name "cacerts"
 default_version "latest"
 
 source url: "https://curl.haxx.se/ca/cacert.pem",
-       sha256: "e62a07e61e5870effa81b430e1900778943c228bd7da1259dd6a955ee2262b47"
+       sha256: "e78c8ab7b4432bd466e64bb942d988f6c0ac91cd785017e465bdc96d42fe9dd0"
 
 relative_path "cacerts-#{version}"
 


### PR DESCRIPTION
The cacerts got a new release today, see https://curl.haxx.se/docs/caextract.html

This PR updated the checksum to that new release