### PR TITLE
[windows] use the system go, in the path, rather than hard-coded

### DIFF
--- a/config/software/datadog-upgrade-helper.rb
+++ b/config/software/datadog-upgrade-helper.rb
@@ -11,10 +11,6 @@ else
   default_version helper_branch
 end
 
-if ohai["platform"] == "windows"
-  gobin = "C:/Go/bin/go"
-end
-
 build do
-  command "#{gobin} build && mv datadog-upgrade-helper #{install_dir}/bin/upgrade-helper", :env => env
+  command "go build && mv datadog-upgrade-helper #{install_dir}/bin/upgrade-helper", :env => env
 end


### PR DESCRIPTION
Go was inexplicably hard-coded to a certain location, which would (obviously) cause a failure if go is installed anywhere else.