### PR TITLE
[jmxfetch] raise rather than fail - rubocop.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,7 @@ before_install:
 
 bundler_args: --jobs 7
 
+env:
+  - JMX_VERSION="0.14.0"
+
 script: bundle exec rake travis:ci

--- a/config/software/jmxfetch.rb
+++ b/config/software/jmxfetch.rb
@@ -2,7 +2,7 @@ name "jmxfetch"
 
 jmx_version = ENV["JMX_VERSION"]
 if jmx_version.nil? || jmx_version.empty?
-  fail "Please specify a JMX_VERSION env variable to build."
+  raise "Please specify a JMX_VERSION env variable to build."
 else
   default_version jmx_version
 end


### PR DESCRIPTION
### Description
Fixing cop issue with the `jmxfetch` definition - use `raise` rather than `fail`