### PR TITLE
Bump Kazoo dependency to 2.4.0

### DIFF
--- a/config/software/kazoo.rb
+++ b/config/software/kazoo.rb
@@ -1,5 +1,5 @@
 name "kazoo"
-default_version "2.2.1"
+default_version "2.4.0"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Pickup a number of bugfixes and minor improvements in the latest version of `kazoo`

Sister PR: https://github.com/DataDog/integrations-core/pull/623