### PR TITLE
Bump kafka-python to 1.3.4

### DIFF
--- a/config/software/kafka-python.rb
+++ b/config/software/kafka-python.rb
@@ -1,5 +1,5 @@
 name "kafka-python"
-default_version "1.3.3"
+default_version "1.3.4"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Pickup some upstream bugfixes.

I'm one of the maintainers of `kafka-python`, so if there are any issues please file a bug and we'll try to get it fixed.

Sister PR: https://github.com/DataDog/integrations-core/pull/684