### PR TITLE
[cx_oracle] adds the definition

### DIFF
--- a/config/software/cx_oracle.rb
+++ b/config/software/cx_oracle.rb
@@ -1,0 +1,12 @@
+name "cx_Oracle"
+default_version "6.0.1"
+
+dependency "python"
+dependency "pip"
+
+build do
+  ship_license "https://raw.githubusercontent.com/oracle/python-cx_Oracle/master/LICENSE.txt"
+  pip "install --install-option=\"--install-scripts="\
+      "#{windows_safe_path(install_dir)}/bin\" "\
+      "#{name}==#{version}"
+end


### PR DESCRIPTION
Definition for `cx_Oracle`, required by the `oracle` integration.

Integration PR: 
https://github.com/DataDog/integrations-core/pull/680