### PR TITLE
[rrdtool] avoid redirect, grab directly from https.

### DIFF
--- a/config/software/python-rrdtool.rb
+++ b/config/software/python-rrdtool.rb
@@ -16,7 +16,7 @@ build do
     end
     command "make", :cwd => "/tmp/ExtUtils-MakeMaker-6.31"
     command "make install", :cwd => "/tmp/ExtUtils-MakeMaker-6.31"
-    command "curl -O http://oss.oetiker.ch/rrdtool/pub/rrdtool-#{version}.tar.gz", :cwd => "/opt/"
+    command "curl -O https://oss.oetiker.ch/rrdtool/pub/rrdtool-#{version}.tar.gz", :cwd => "/opt/"
     command "tar -xzvf rrdtool-#{version}.tar.gz", :cwd => "/opt/"
     command "./configure", :cwd => "/opt/rrdtool-#{version}", :env => { "PKG_CONFIG_PATH" => "/usr/lib/pkgconfig/" }
     command "make", :cwd => "/opt/rrdtool-#{version}", :env => { "PKG_CONFIG_PATH" => "/usr/lib/pkgconfig/" }


### PR DESCRIPTION
Grabbing from `http://foo` was breaking the build due to the reditect - this pulls directly from `https` which is the right thing to do anyways.