### PR TITLE
add line for netbsd from change in gopacket

### DIFF
--- a/config/patches/datadog-metro/libpcap-static-link.patch
+++ b/config/patches/datadog-metro/libpcap-static-link.patch
@@ -2,7 +2,7 @@ diff --git a/pcap/pcap.go b/pcap/pcap.go
 index b8eb666..9a623cd 100644
 --- a/pcap/pcap.go
 +++ b/pcap/pcap.go
-@@ -9,11 +9,12 @@ package pcap
+@@ -9,12 +9,13 @@ package pcap
  
  /*
  #cgo solaris LDFLAGS: -L /opt/local/lib -lpcap
@@ -12,6 +12,7 @@ index b8eb666..9a623cd 100644
  #cgo dragonfly LDFLAGS: -lpcap
  #cgo freebsd LDFLAGS: -lpcap
  #cgo openbsd LDFLAGS: -lpcap
+ #cgo netbsd LDFLAGS: -lpcap
 -#cgo darwin LDFLAGS: -lpcap
 +#cgo darwin LDFLAGS: /usr/local/Cellar/libpcap/1.7.4/lib/libpcap.a
  #cgo windows CFLAGS: -I C:/WpdPack/Include


### PR DESCRIPTION
The datadog-metro build will break because of this change in gopacket a couple days ago: https://github.com/google/gopacket/commit/895488bc9260b091df44a3937a15cef7b0aaae6a#diff-69b81a223850b8b6476f978036525756

The proper solution would probably be to pin gopacket to a specific tag or branch.