### PR TITLE
[sysstat] disable sensors - wasnt provided in the past.

### DIFF
--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -17,7 +17,7 @@ build do
   ship_license "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
   command(["./configure",
        "--prefix=#{install_dir}/embedded",
-       "--disable-nls"].join(" "),
+       "--disable-nls", "--disable-sensors"].join(" "),
     :env => env)
   command "make -j #{workers}", :env => { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"


### PR DESCRIPTION
So although we probably want to enable support for `libsensors` into `sysstat`, we didn't provide this in the past. So let's disable it until we add the libsensors definition.

Note: it should've been straight-forward to fix, but I ran into some issues as libsensors appeared to depend on flex, and bison, and then I hit some unexpected error related to `yacc`. So until we figure that out, this probably makes sense. 