### PR TITLE
[supervisord] bumping to 3.3.3

### DIFF
--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -1,5 +1,5 @@
 name "supervisor"
-default_version "3.3.0"
+default_version "3.3.3"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Bumping supervisor to 3.3.3 to address known vulnerablity: [CVE-2017-11610](https://github.com/Supervisor/supervisor/issues/964)