### PR TITLE
Avoid sourceforge downloads

### DIFF
--- a/config/software/net-snmp-lib.rb
+++ b/config/software/net-snmp-lib.rb
@@ -12,7 +12,7 @@ end
 dependency "zlib"
 dependency "openssl"
 
-source url: "https://downloads.sourceforge.net/project/net-snmp/net-snmp/#{version}/net-snmp-#{version}.tar.gz",
+source url: "https://dd-agent.s3.amazonaws.com/net-snmp/net-snmp-#{version}.tar.gz",
        extract: :seven_zip
 
 relative_path "net-snmp-#{version}"

--- a/config/software/net-snmp.rb
+++ b/config/software/net-snmp.rb
@@ -8,7 +8,7 @@ end
 dependency "zlib"
 dependency "openssl"
 
-source url: "https://downloads.sourceforge.net/project/net-snmp/net-snmp/#{version}/net-snmp-#{version}.tar.gz",
+source url: "https://dd-agent.s3.amazonaws.com/net-snmp/net-snmp-#{version}.tar.gz",
        extract: :seven_zip
 
 relative_path "net-snmp-#{version}"

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -18,7 +18,7 @@ name "zlib"
 default_version "1.2.11"
 
 version "1.2.11" do
-  source md5: "1c9f62f0778697a09d36121ead88e08e"
+  source sha256: "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
 end
 
 version "1.2.8" do
@@ -28,7 +28,7 @@ version "1.2.6" do
   source md5: "618e944d7c7cd6521551e30b32322f4a"
 end
 
-source url: "http://downloads.sourceforge.net/project/libpng/zlib/#{version}/zlib-#{version}.tar.gz",
+source url: "https://zlib.net/zlib-#{version}.tar.gz",
        extract: :seven_zip
 
 relative_path "zlib-#{version}"


### PR DESCRIPTION
Avoid downloading source from sourceforge for 2 deps the `datadog-agent` omnibus build relies on:
* zlib: download from upstream
* net-snmp: download from our S3 bucket

SourceForge is too unreliable, avoid using it.