### PR TITLE
[unixodbc] add software definition + pyopenssl/cryprograhy upgrade

### DIFF
--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -1,5 +1,5 @@
 name "cryptography"
-default_version "1.7.1"
+default_version "2.1.4"
 
 dependency "python"
 dependency "pip"

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -1,6 +1,6 @@
 name "pyopenssl"
 # If you upgrade pyopenssl, you'll probably have to upgrade `cryptography` as well
-default_version "0.14"
+default_version "17.5.0"
 
 dependency "python"
 dependency "pip"

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -14,7 +14,7 @@ source :url => "https://downloads.sourceforge.net/unixodbc/unixODBC-#{version}.t
 build do
   ship_license "LGPLv2"
   env = with_standard_compiler_flags(with_embedded_path)
-  
+
   configure_args = [
     "--disable-readline",
     "--prefix=#{install_dir}/embedded",

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -1,10 +1,6 @@
 name "unixodbc"
 default_version "2.3.4"
 
-dependency "automake"
-dependency "autoconf"
-dependency "libtool"
-
 version "2.3.4" do
   source :sha256 => "2e1509a96bb18d248bf08ead0d74804957304ff7c6f8b2e5965309c632421e39"
 end

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -1,0 +1,28 @@
+name "unixodbc"
+default_version "2.3.4"
+
+dependency "automake"
+dependency "autoconf"
+dependency "libtool"
+
+version "2.3.4" do
+  source :sha256 => "2e1509a96bb18d248bf08ead0d74804957304ff7c6f8b2e5965309c632421e39"
+end
+
+source :url => "https://downloads.sourceforge.net/unixodbc/unixODBC-#{version}.tar.gz"
+
+build do
+  ship_license "LGPLv2"
+  env = with_standard_compiler_flags(with_embedded_path)
+  
+  configure_args = [
+    "--disable-readline",
+    "--prefix=#{install_dir}/embedded",
+  ]
+
+  configure_command = configure_args.unshift("./configure").join(" ")
+
+  command configure_command, cwd: "#{Omnibus::Config.source_dir}/unixodbc/unixODBC-#{version}", env: env, in_msys_bash: true
+  make env: env, cwd: "#{Omnibus::Config.source_dir}/unixodbc/unixODBC-#{version}"
+  make "install", cwd: "#{Omnibus::Config.source_dir}/unixodbc/unixODBC-#{version}", env: env
+end


### PR DESCRIPTION
`unixodbc` is required by `SQLserver`. We were not currently shipping it although it is technically a linux-compatible integration. 

Also upgraded pyopenssl and cryptography to match integrations requirements, it was probably about time to upgrade both. I haven't encountered any issue in testing, but please let me know if anyone has any issues with that upgrade.