### PR TITLE
Fix JMXFetch jar permissions

### DIFF
--- a/config/software/jmxfetch.rb
+++ b/config/software/jmxfetch.rb
@@ -52,5 +52,6 @@ relative_path "jmxfetch"
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
   mkdir jar_dir
-  copy "jmxfetch-*-jar-with-dependencies.jar", jar_dir
+  copy "jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar", jar_dir
+  block { File.chmod(0644, "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar") }
 end

--- a/config/software/jmxfetch.rb
+++ b/config/software/jmxfetch.rb
@@ -52,6 +52,6 @@ relative_path "jmxfetch"
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
   mkdir jar_dir
-  copy "jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar", jar_dir
-  block { File.chmod(0644, "#{jar_dir}/jmxfetch-#{jmxfetch_version}-jar-with-dependencies.jar") }
+  copy "jmxfetch-#{version}-jar-with-dependencies.jar", jar_dir
+  block { File.chmod(0644, "#{jar_dir}/jmxfetch-#{version}-jar-with-dependencies.jar") }
 end


### PR DESCRIPTION
### What does this PR do?

Modify the permissions of JMXFetch jar from 0600 to 0644.

### Motivation

For some reason JMXFetch jar permissions were set to `0600`. On mac osx a standard install will result in all files in `/opt/datadog-agent` being owned by `root`. Under these conditions it was not possible for the agent to read the jar file. 

Fixes https://github.com/DataDog/dd-agent/issues/3512.

Agent6: https://github.com/DataDog/datadog-agent/pull/1170.