### PR TITLE
[openssl] bumping openssl version to 1.0.2o

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,12 +24,13 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 
-default_version "1.0.2k"
+default_version "1.0.2o"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.0.2o") { source sha256: "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" }
 version("1.0.2k") { source sha256: "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" }
 version("1.0.2j") { source sha256: "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" }
 version("1.0.2i") { source sha256: "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f" }


### PR DESCRIPTION
Bumps openssl to a more current version.

OpenSSL is currently still maintaining the `1.0.x` branch, but `1.1.x` is out too. Maybe the next upgrade should contemplate a minor bump as well.