### PR TITLE
[protobuf] static build + wheel, no bloat + RHEL support

### DIFF
--- a/config/patches/protobuf-py/setup-py-no-debug-symbols-for-gcc-41.patch
+++ b/config/patches/protobuf-py/setup-py-no-debug-symbols-for-gcc-41.patch
@@ -1,0 +1,13 @@
+diff -ur protobuf-3.5.1/python/setup.py protobuf-3.5.1-patched/python/setup.py
+--- protobuf-3.5.1/python/setup.py	2017-12-18 22:53:23.000000000 +0100
++++ protobuf-3.5.1-patched/python/setup.py	2018-04-23 11:08:20.000000000 +0200
+@@ -180,7 +180,8 @@
+     compile_static_ext = get_option_from_sys_argv('--compile_static_extension')
+     extra_compile_args = ['-Wno-write-strings',
+                           '-Wno-invalid-offsetof',
+-                          '-Wno-sign-compare']
++                          '-Wno-sign-compare',
++                          '-g0',]
+     libraries = ['protobuf']
+     extra_objects = None
+     if compile_static_ext:

--- a/config/software/protobuf-py.rb
+++ b/config/software/protobuf-py.rb
@@ -36,7 +36,7 @@ build do
     # command "cd .. && make check"
     command "cd .. && make -j #{workers}"
 
-    if ohai["platform_family"] == "rhel"
+    if ohai["platform_family"] == "rhel" && ohai["platform_version"].to_i == 5
       patch :source => "setup-py-no-debug-symbols-for-gcc-41.patch", :plevel => 2
     end
     # Python lib

--- a/config/software/protobuf-py.rb
+++ b/config/software/protobuf-py.rb
@@ -34,6 +34,9 @@ build do
   # command "cd .. && make check"
   command "cd .. && make -j #{workers}"
 
+  if ohai["platform_family"] == "rhel"
+    patch :source => "setup-py-no-debug-symbols-for-gcc-41.patch", :plevel => 2
+  end
   # Python lib
   command ["#{install_dir}/embedded/bin/python",
          "setup.py",


### PR DESCRIPTION
Newer `protobuf` versions removed the old GCC (4.1) build issues, however I was still getting some issues building the wheel on RHEL, removing debug symbols allowed me to successfully complete the build. 

Unfortunately windows would require added work and we don't really need the C++ protobuf bindings on the platform, so we'll just continue shipping the pure-python variant there. 