### PR TITLE
[six] bumping version to 1.11.0

### DIFF
--- a/config/software/six.rb
+++ b/config/software/six.rb
@@ -1,5 +1,5 @@
 name "six"
-default_version "1.10.0"
+default_version "1.11.0"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Not aligned with `datadog-checks-base`. This is a temporary fix. The end-goal is to have a single source of truth, that will live in `integrations-core`. Very soon we'll be using the UCS4 wheels for protobuf-py, so we will not need to use this software definition, effectively solving the problem.

But let's bump anyways.