### PR TITLE
ship prebuilt gometro on RHEL

### DIFF
--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,5 +1,5 @@
 name "datadog-gohai"
-default_version "last-stable"
+default_version "arbll/go1.10"
 
 always_build true
 

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,5 +1,5 @@
 name "datadog-gohai"
-default_version "arbll/go1.10"
+default_version "last-stable"
 
 always_build true
 

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -1,5 +1,5 @@
 name "datadog-metro"
-default_version "last-stable"
+default_version "1.0.0"
 
 always_build true
 
@@ -10,9 +10,12 @@ env = {
 
 dependency "libpcap"
 
+version "1.0.0" do
+  source :sha256 => "a6fb05dcbe0f412eaac44095db67a8d71cce6c66dc900b0b78258de4ee43bf2f"
+end
+
 if ohai["platform_family"] == "rhel"
-  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6-1.0.0",
-         :sha256 => "a6fb05dcbe0f412eaac44095db67a8d71cce6c66dc900b0b78258de4ee43bf2f"
+  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6-#{version}",
 end
 
 #TODO: complete OSX support.

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -10,6 +10,11 @@ env = {
 
 dependency "libpcap"
 
+if ohai["platform_family"] == "rhel"
+  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6",
+         :sha256 => "a6fb05dcbe0f412eaac44095db67a8d71cce6c66dc900b0b78258de4ee43bf2f",
+end
+
 #TODO: complete OSX support.
 if ohai["platform_family"] == "mac_os_x"
   env.delete "GOROOT"
@@ -21,16 +26,21 @@ end
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/go-metro/master/LICENSE"
   ship_license "https://raw.githubusercontent.com/DataDog/go-metro/master/THIRD_PARTY_LICENSES.md"
-  command "mkdir -p /var/cache/omnibus/src/datadog-metro/src/github.com/DataDog", :env => env
-  command "#{gobin} get -v -d github.com/DataDog/go-metro", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-  command "git checkout #{default_version} && git pull", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro/src/github.com/DataDog/go-metro"
-  command "#{gobin} get -v -d github.com/cihub/seelog", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-  command "#{gobin} get -v -d github.com/google/gopacket", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-  command "#{gobin} get -v -d github.com/DataDog/datadog-go/statsd", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-  command "#{gobin} get -v -d gopkg.in/tomb.v2", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-  command "#{gobin} get -v -d gopkg.in/yaml.v2", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-  patch :source => "libpcap-static-link.patch", :plevel => 1,
-        :acceptable_output => "Reversed (or previously applied) patch detected",
-        :target => "/var/cache/omnibus/src/datadog-metro/src/github.com/google/gopacket/pcap/pcap.go"
-  command "#{gobin} build -o #{install_dir}/bin/go-metro github.com/DataDog/go-metro", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+
+  if ohai["platform_family"] == "rhel"
+    command "mv gometro-centos6 #{install_dir}/bin/go-metro"
+  else
+    command "mkdir -p /var/cache/omnibus/src/datadog-metro/src/github.com/DataDog", :env => env
+    command "#{gobin} get -v -d github.com/DataDog/go-metro", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+    command "git checkout #{default_version} && git pull", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro/src/github.com/DataDog/go-metro"
+    command "#{gobin} get -v -d github.com/cihub/seelog", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+    command "#{gobin} get -v -d github.com/google/gopacket", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+    command "#{gobin} get -v -d github.com/DataDog/datadog-go/statsd", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+    command "#{gobin} get -v -d gopkg.in/tomb.v2", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+    command "#{gobin} get -v -d gopkg.in/yaml.v2", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+    patch :source => "libpcap-static-link.patch", :plevel => 1,
+          :acceptable_output => "Reversed (or previously applied) patch detected",
+          :target => "/var/cache/omnibus/src/datadog-metro/src/github.com/google/gopacket/pcap/pcap.go"
+    command "#{gobin} build -o #{install_dir}/bin/go-metro github.com/DataDog/go-metro", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
+  end
 end

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -15,7 +15,7 @@ version "1.0.0" do
 end
 
 if ohai["platform_family"] == "rhel"
-  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6-#{version}",
+  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6-#{version}"
 end
 
 #TODO: complete OSX support.

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -12,7 +12,7 @@ dependency "libpcap"
 
 if ohai["platform_family"] == "rhel"
   source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6",
-         :sha256 => "a6fb05dcbe0f412eaac44095db67a8d71cce6c66dc900b0b78258de4ee43bf2f",
+         :sha256 => "a6fb05dcbe0f412eaac44095db67a8d71cce6c66dc900b0b78258de4ee43bf2f"
 end
 
 #TODO: complete OSX support.

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -11,7 +11,7 @@ env = {
 dependency "libpcap"
 
 if ohai["platform_family"] == "rhel"
-  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6",
+  source :url => "https://s3.amazonaws.com/dd-agent/go-metro/gometro-centos6-1.0.0",
          :sha256 => "a6fb05dcbe0f412eaac44095db67a8d71cce6c66dc900b0b78258de4ee43bf2f"
 end
 

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -35,7 +35,7 @@ build do
   else
     command "mkdir -p /var/cache/omnibus/src/datadog-metro/src/github.com/DataDog", :env => env
     command "#{gobin} get -v -d github.com/DataDog/go-metro", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
-    command "git checkout #{default_version} && git pull", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro/src/github.com/DataDog/go-metro"
+    command "git checkout #{version} && git pull", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro/src/github.com/DataDog/go-metro"
     command "#{gobin} get -v -d github.com/cihub/seelog", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
     command "#{gobin} get -v -d github.com/google/gopacket", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"
     command "#{gobin} get -v -d github.com/DataDog/datadog-go/statsd", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"


### PR DESCRIPTION
Our builder is based on centos5. Building gometro with a recent version of go on it was deemed too much work. Instead we'll ship a prebuilt binary.
It was built in almost the same builder docker image with centos6 instead of centos5.