### PR TITLE
[go-metro] make executable after copying over

### DIFF
--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -32,6 +32,7 @@ build do
 
   if ohai["platform_family"] == "rhel"
     command "mv gometro-centos6-#{version} #{install_dir}/bin/go-metro"
+    command "chmod ug+x #{install_dir}/bin/go-metro"
   else
     command "mkdir -p /var/cache/omnibus/src/datadog-metro/src/github.com/DataDog", :env => env
     command "#{gobin} get -v -d github.com/DataDog/go-metro", :env => env, :cwd => "/var/cache/omnibus/src/datadog-metro"


### PR DESCRIPTION
After download go-metro might not be executable, make sure it is.