### PR TITLE
[docker-py] Remove `install-option` from docker-py pip install

### DIFF
--- a/config/software/docker-py.rb
+++ b/config/software/docker-py.rb
@@ -6,5 +6,7 @@ dependency "pip"
 
 build do
   ship_license "Apachev2"
-  pip "install --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\" #{name}==#{version}"
+  # Don't use --install-option to specify the scripts path, as this disables wheels, and one of the
+  # docker-py deps (pywin32) can only be installed with a wheel
+  pip "install #{name}==#{version}"
 end


### PR DESCRIPTION
Follow-up to https://github.com/DataDog/dd-agent-omnibus/pull/275, docker-py install is now failing.

Don't use --install-option to specify the scripts path, as this disables wheels, and one of the
docker-py deps (pywin32) can only be installed with a wheel. docker-py doesn't ship any scripts anyway.