### PR TITLE
Compile python with -fPIC

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -32,7 +32,7 @@ if ohai["platform"] != "windows"
   relative_path "Python-#{version}"
 
   env = {
-    "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -g -pipe",
+    "CFLAGS" => "-I#{install_dir}/embedded/include -O2 -g -pipe -fPIC",
     "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
   }
 


### PR DESCRIPTION
Running the omnibus recipes on arm currently will fail when compiling python with the following error:

```
# github.com/DataDog/datadog-agent/vendor/github.com/sbinet/go-python
/usr/bin/ld: /opt/datadog-agent/embedded/lib/libpython2.7.a(abstract.o): relocation R_ARM_THM_MOVW_ABS_NC against `_Py_NotImplementedStruct' can not be used when making a shared object; recompile with -fPIC
/opt/datadog-agent/embedded/lib/libpython2.7.a: error adding symbols: Bad value
collect2: error: ld returned 1 exit status
```

This PR adds `-fPIC` to the CFLAGS used to compile python.