### PR TITLE
Bump psutil to 5.4.7

### DIFF
--- a/config/software/psutil.rb
+++ b/config/software/psutil.rb
@@ -1,5 +1,5 @@
 name "psutil"
-default_version "4.4.1"
+default_version "5.4.7"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
Bumps psutil to version 5.4.7  to match what integrations-core defined it as. 

Integrations-core PR that bumped this - https://github.com/DataDog/integrations-core/pull/2190