### PR TITLE
[datadog-a7] Pin configparser to working version

### DIFF
--- a/config/software/datadog-a7.rb
+++ b/config/software/datadog-a7.rb
@@ -7,5 +7,7 @@ build do
   ship_license "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
-      "#{name}==#{version}"
+      "#{name}==#{version}"\
+      "configparser==3.5.0" # this pins a dependency of pylint->datadog-a7, later versions (up to v3.7.1) are broken.
+                            # TODO: all deps should be pinned.
 end


### PR DESCRIPTION
Temp fix to fix the Agent build, long term we should pin all the deps.

**WIP until omnibus build is confirmed to pass with this fix**