### PR TITLE
Add datadog-vsphere integration

### DIFF
--- a/config/software/datadog-vsphere.rb
+++ b/config/software/datadog-vsphere.rb
@@ -4,7 +4,8 @@ default_version "3.6.2"
 dependency "python"
 dependency "pip"
 
+wheel_name = name.sub(/-/, "_")
+
 build do
-  wheel_name = name.sub(/-/, "_")
   pip "install https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/#{name}/#{wheel_name}-#{version}-py2.py3-none-any.whl"
 end

--- a/config/software/datadog-vsphere.rb
+++ b/config/software/datadog-vsphere.rb
@@ -1,0 +1,10 @@
+name "datadog-vsphere"
+default_version "3.6.2"
+
+dependency "python"
+dependency "pip"
+
+build do
+  wheel_name name.sub(/-/, "_")
+  pip "install https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/#{name}/#{wheel_name}-#{version}-py2.py3-none-any.whl"
+end

--- a/config/software/datadog-vsphere.rb
+++ b/config/software/datadog-vsphere.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  wheel_name name.sub(/-/, "_")
+  wheel_name = name.sub(/-/, "_")
   pip "install https://dd-integrations-core-wheels-build-stable.s3.amazonaws.com/targets/simple/#{name}/#{wheel_name}-#{version}-py2.py3-none-any.whl"
 end


### PR DESCRIPTION
we can’t ship the latest version of the vsphere check in agent 5, because it now waits for the threads to finish running before returning from the check function, which might cause a problem if it takes too long.