### PR TITLE
[xproto] Ship license in source instead of downloading it separately

### DIFF
--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -38,7 +38,7 @@ configure_env =
   end
 
 build do
-  ship_license "http://cgit.freedesktop.org/xorg/util/macros/plain/COPYING"
+  ship_license "COPYING"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -38,7 +38,7 @@ configure_env =
   end
 
 build do
-  ship_license "COPYING"
+  ship_license "./COPYING"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -38,7 +38,7 @@ configure_env =
   end
 
 build do
-  ship_license "http://cgit.freedesktop.org/xorg/proto/xproto/plain/COPYING"
+  ship_license "COPYING"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -38,7 +38,7 @@ configure_env =
   end
 
 build do
-  ship_license "COPYING"
+  ship_license "./COPYING"
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}", :env => configure_env
   command "make -j #{workers} install", :env => configure_env


### PR DESCRIPTION
Requires https://github.com/DataDog/omnibus-ruby/pull/80

Rationale explained there, we want this for `xproto` because `http://cgit.freedesktop.org` is down ATM.

Tested on a gitlab pipeline: build passes, license files are in correct location