### PR TITLE
remove setx from python def; it's not necessary and leaves bad artifacts

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -88,6 +88,5 @@ else
             "\"#{windows_safe_path(install_dir)}\\embedded\" /L uninstallation_logs.txt "\
             "ADDLOCAL=DefaultFeature  /qn"
 
-    command "SETX PYTHONPATH \"#{windows_safe_path(install_dir)}\\embedded\""
   end
 end


### PR DESCRIPTION
on development/build systems

Remove the setx command from the build definition.

It's not necessary, and it leaves an artifact; namely, it sets your PYTHON path to your embedded directory rather than the system path. All of our definitions explicitly call the python from the embedded directory, so it's not necessary