### PR TITLE
Adds windows to `datadog-agent-six`

### DIFF
--- a/config/software/datadog-agent-six.rb
+++ b/config/software/datadog-agent-six.rb
@@ -1,5 +1,5 @@
 name "datadog-agent-six"
-default_version "0.1.0"
+default_version "master"
 
 dependency "python2"
 dependency "python3"
@@ -8,9 +8,7 @@ license "Apache"
 license_file "LICENSE"
 skip_transitive_dependency_licensing true
 
-source :url => "https://github.com/DataDog/datadog-agent-six/archive/v#{version}.tar.gz",
-       :sha256 => "ec6a63b38d99b6159a28f05c6c29c653a767c67323a58976bc2e05913b7b8733",
-       :extract => :seven_zip
+source :git => "git://github.com/DataDog/datadog-agent-six"
 
 relative_path "datadog-agent-six-#{version}"
 

--- a/config/software/datadog-agent-six.rb
+++ b/config/software/datadog-agent-six.rb
@@ -25,7 +25,7 @@ if ohai["platform"] != "windows"
     command "make install"
   end
 else
- build do
+  build do
     env = {
         "Python2_ROOT_DIR" => "#{windows_safe_path(python_2_embedded)}",
         "Python3_ROOT_DIR" => "#{windows_safe_path(python_3_embedded)}",

--- a/config/software/datadog-agent-six.rb
+++ b/config/software/datadog-agent-six.rb
@@ -14,14 +14,27 @@ source :url => "https://github.com/DataDog/datadog-agent-six/archive/v#{version}
 
 relative_path "datadog-agent-six-#{version}"
 
-build do
-  env = {
-    "Python2_ROOT_DIR" => "#{install_dir}/embedded",
-    "Python3_ROOT_DIR" => "#{install_dir}/embedded",
-    "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
-  }
+if ohai["platform"] != "windows"
+  build do
+    env = {
+        "Python2_ROOT_DIR" => "#{install_dir}/embedded",
+        "Python3_ROOT_DIR" => "#{install_dir}/embedded",
+        "LDFLAGS" => "-Wl,-rpath,#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib",
+    }
 
-  command "cmake -DCMAKE_INSTALL_PREFIX:PATH=#{install_dir}/embedded .", :env => env
-  command "make -j #{workers}"
-  command "make install"
+    command "cmake -DCMAKE_INSTALL_PREFIX:PATH=#{install_dir}/embedded .", :env => env
+    command "make -j #{workers}"
+    command "make install"
+  end
+else
+ build do
+    env = {
+        "Python2_ROOT_DIR" => "#{windows_safe_path(python_2_embedded)}",
+        "Python3_ROOT_DIR" => "#{windows_safe_path(python_3_embedded)}",
+    }
+
+    command "cmake -G \"Unix Makefiles\" .", :env => env
+    command "make -j #{workers}"
+    command "make install"
+  end
 end


### PR DESCRIPTION
Adds windows options to `datadog-agent-six`

Note that this definition doesn't put the DLLs anywhere useful (yet).  Mostly because we haven't decided where they should go (on windows).

Also note I changed the definition from a static tarball to `git:master`; needed up-to-date version to make it work on windows.