### PR TITLE
[pyyaml] bumping to 5.1

### DIFF
--- a/config/software/pyyaml.rb
+++ b/config/software/pyyaml.rb
@@ -1,5 +1,5 @@
 name "pyyaml"
-default_version "3.11"
+default_version "5.1"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
### What does this PR do?

Bumps PyYaml to the latest 5.1.

### Motivation

Enable new `full_load()` option for customers perhaps wanting to use that after `load_all()` was patched for security reasons.

### Notes

Cherry-pick to `agent-v5` branch.

Related PR: https://github.com/DataDog/dd-agent/pull/3839
