### PR TITLE
[cacerts] Use target_filename to define name of downloaded file

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -21,7 +21,8 @@ name "cacerts"
 default_version "latest"
 
 source url: "https://curl.haxx.se/ca/cacert.pem",
-       sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000"
+       sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000",
+       target_filename: "cacert.pem"
 
 relative_path "cacerts-#{version}"
 

--- a/config/software/cacerts_py2.rb
+++ b/config/software/cacerts_py2.rb
@@ -21,7 +21,8 @@ name "cacerts_py2"
 default_version "latest"
 
 source url: "https://curl.haxx.se/ca/cacert.pem",
-       sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000"
+       sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000",
+       target_filename: "cacert.pem"
 
 relative_path "cacerts-#{version}"
 

--- a/config/software/cacerts_py3.rb
+++ b/config/software/cacerts_py3.rb
@@ -21,7 +21,8 @@ name "cacerts_py3"
 default_version "latest"
 
 source url: "https://curl.haxx.se/ca/cacert.pem",
-       sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000"
+       sha256: "c1fd9b235896b1094ee97bfb7e042f93530b5e300781f59b45edf84ee8c75000",
+       target_filename: "cacert.pem"
 
 relative_path "cacerts-#{version}"
 


### PR DESCRIPTION
Required by https://github.com/DataDog/omnibus-ruby/pull/82. See details there.

I checked these were the only software defs used by the Agent v6 build in `omnibus-software` that downloaded a single non-archive file using the `NetFetcher`.