### PR TITLE
Update autoconf config information to support building on newer platforms

### DIFF
--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -31,7 +31,7 @@ env = {
 }
 
 build do
-  update_config_guess(target: 'build-aux')
+  update_config_guess(target: "build-aux")
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}"
   command "make install"

--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -18,6 +18,8 @@
 name "autoconf"
 default_version "2.68"
 
+dependency "config_guess"
+
 source :url => "http://ftp.gnu.org/gnu/autoconf/autoconf-2.68.tar.gz",
        :md5 => "c3b5247592ce694f7097873aa07d66fe"
 
@@ -29,6 +31,7 @@ env = {
 }
 
 build do
+  update_config_guess(target: 'build-aux')
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}"
   command "make install"

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -33,7 +33,7 @@ configure_env = {
 }
 
 build do
-  update_config_guess(target: 'lib')
+  update_config_guess(target: "lib")
   command "./bootstrap", :env => { "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}" }
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}"

--- a/config/software/automake.rb
+++ b/config/software/automake.rb
@@ -19,6 +19,7 @@ name "automake"
 default_version "1.11.2"
 
 dependency "autoconf"
+dependency "config_guess"
 
 source :url => "http://ftp.gnu.org/gnu/automake/automake-1.11.2.tar.gz",
        :md5 => "79ad64a9f6e83ea98d6964cef8d8a0bc"
@@ -32,6 +33,7 @@ configure_env = {
 }
 
 build do
+  update_config_guess(target: 'lib')
   command "./bootstrap", :env => { "PATH" => "#{install_dir}/embedded/bin:#{ENV['PATH']}" }
   command "./configure --prefix=#{install_dir}/embedded", :env => configure_env
   command "make -j #{workers}"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -19,6 +19,7 @@ name "libiconv"
 default_version "1.14"
 
 dependency "libgcc"
+dependency "config_guess"
 
 source :url => "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        :md5 => "e34509b1623cec449dfeb73d7ce9c6c6",
@@ -55,6 +56,9 @@ end
 
 build do
   patch :source => "libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch"
+  update_config_guess(target: 'build-aux')
+  update_config_guess(target: 'libcharset/build-aux')
+
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}", :env => env
   command "make -j #{workers} install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", :env => env

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -56,8 +56,8 @@ end
 
 build do
   patch :source => "libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch"
-  update_config_guess(target: 'build-aux')
-  update_config_guess(target: 'libcharset/build-aux')
+  update_config_guess(target: "build-aux")
+  update_config_guess(target: "libcharset/build-aux")
 
   command "./configure --prefix=#{install_dir}/embedded", :env => env
   command "make -j #{workers}", :env => env

--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -1,6 +1,8 @@
 name "libsqlite3"
 default_version "3.7.7.1"
 
+dependency "config_guess"
+
 source :git => "git://github.com/LuaDist/libsqlite3.git"
 
 relative_path "libsqlite3"
@@ -12,6 +14,7 @@ env = {
 }
 
 build do
+  update_config_guess
   command(["./configure",
        "--prefix=#{install_dir}/embedded",
        "--disable-nls"].join(" "),

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -21,6 +21,7 @@ default_version "1.1.28"
 dependency "libxml2"
 dependency "libtool" if ohai["platform"] == "solaris2"
 dependency "liblzma"
+dependency "config_guess"
 
 version "1.1.26" do
   source md5: "e61d0364a30146aaa3001296f853b2b9"
@@ -40,6 +41,9 @@ build do
     "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
     "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
   }
+
+  update_config_guess
+
   command(["./configure",
            "--prefix=#{install_dir}/embedded",
            "--with-libxml-prefix=#{install_dir}/embedded",

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -20,6 +20,7 @@ default_version "5.9"
 
 dependency "libgcc"
 dependency "libtool" if ohai["platform"] == "aix"
+dependency "config_guess"
 
 source url: "http://ftp.gnu.org/gnu/ncurses/ncurses-5.9.tar.gz",
        md5: "8cb9c412e5f2d96bc6f459aa8c6282a1",
@@ -97,6 +98,8 @@ build do
     # to remove this after upgrading to any release created after June 2012
     patch source: "ncurses-clang.patch"
   end
+
+  update_config_guess
 
   # build wide-character libraries
   cmd_array = ["./configure",


### PR DESCRIPTION
This PR fixes the following error that occurs when compiling various libraries on an arm64 box:

```
  Error:

    ./config.guess: unable to guess system type

This script, last modified 2009-02-03, has failed to recognize
the operating system you are using. It is advised that you
download the most up to date version of the config scripts from

  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.guess;hb=HEAD
and
  http://git.savannah.gnu.org/gitweb/?p=config.git;a=blob_plain;f=config.sub;hb=HEAD

If the version you run (./config.guess) is already up to date, please
send the following data and any information you think might be
pertinent to <config-patches@gnu.org> in order to provide the needed
information to handle your system.
```

This built-in method is already in use in the repo here for example https://github.com/DataDog/omnibus-software/blob/master/config/software/libtool.rb#L38-L39