### PR TITLE
[ship_source] Change software definitions for software using ship_source

### DIFF
--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -24,6 +24,8 @@ version "0.28" do
   source md5: "aa3c86e67551adc3ac865160e34a2a0d"
 end
 
+ship_source true
+
 source url: "http://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz",
        :extract => :seven_zip
 
@@ -35,7 +37,6 @@ env = with_standard_compiler_flags(env, :aix => { :use_gcc => true })
 paths = [ "#{install_dir}/embedded/bin/pkgconfig" ]
 
 build do
-  ship_source "http://pkgconfig.freedesktop.org/releases/pkg-config-#{version}.tar.gz"
   command "./configure --prefix=#{install_dir}/embedded --disable-debug --disable-host-tool --with-internal-glib --with-pc-path=#{paths * ':'}", :env => env
   # #203: pkg-configs internal glib does not provide a way to pass ldflags.
   # Only allows GLIB_CFLAGS and GLIB_LIBS.

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -1,6 +1,8 @@
 name "procps-ng"
 default_version "3.3.9"
 
+ship_source true
+
 source :url => "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz",
        :md5 => "0980646fa25e0be58f7afb6b98f79d74"
 
@@ -13,7 +15,6 @@ env = {
 }
 
 build do
-  ship_source "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz"
   ship_license "https://gitlab.com/procps-ng/procps/raw/master/COPYING"
   command(["./configure",
            "--prefix=#{install_dir}/embedded",

--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -1,6 +1,8 @@
 name "sysstat"
 default_version "11.1.3"
 
+ship_source true
+
 source :url => "https://github.com/sysstat/sysstat/archive/v#{version}.tar.gz",
        :sha256 => "e76dff7fa9246b94c4e1efc5ca858422856e110f09d6a58c5bf6000ae9c9d16e"
 
@@ -13,7 +15,6 @@ env = {
 }
 
 build do
-  ship_source "https://github.com/sysstat/sysstat/archive/v#{version}.tar.gz"
   ship_license "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
   command(["./configure",
        "--prefix=#{install_dir}/embedded",


### PR DESCRIPTION
# Description

Following a change on how source shipping is done in the `omnibus-ruby` repo, the corresponding software definitions have been changed.

[This omnibus-ruby PR](https://github.com/DataDog/omnibus-ruby/pull/83) should be merged before this PR, as it implements the `ship_source` method change.