### PR TITLE
Update libyaml to 0.2.2

### DIFF
--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -42,5 +42,5 @@ build do
   # First extract the zip file
   command "7z.exe x #{project_file} -o#{temp_directory} "
   # Now copy over libyaml-0-2.dll to the build dir
-  copy("#{temp_directory}/bin/libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll")
+  copy("#{temp_directory}/bin/libyaml-0-2.dll", "#{windows_safe_path(python_2_embedded)}/DLLs/libyaml-0-2.dll")
 end

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -39,10 +39,8 @@ build do
 
   # Ensure the directory exists
   mkdir temp_directory
-  # First extract the tar file out of lzma archive.
-  command "7z.exe x #{project_file} -o#{temp_directory} -r -y"
-  # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(temp_directory, "libyaml-#{version}-x64-windows.zip")} -o#{temp_directory} -r -y"
+  # First extract the zip file
+  command "7z.exe x #{project_file} -o#{temp_directory} "
   # Now copy over libyaml-0-2.dll to the build dir
   copy("#{temp_directory}/bin/libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll")
 end

--- a/config/software/libyaml-windows.rb
+++ b/config/software/libyaml-windows.rb
@@ -25,13 +25,13 @@
 # of rubyinstaller.org
 #
 name "libyaml-windows"
-default_version "0.1.7"
+default_version "0.2.2"
 
-version "0.1.7" do
-  source sha256: "c90f4a678a7901bf0c48fc50cd6ffbd96eeb0b0184ba6c853fc0f54702213674"
+version "0.2.2" do
+  source sha256: "9d430d3788081027a2dcf13fb8823b5ee296b1c8fe0353c86339b4c7b4018441"
 end
 
-source :url => "https://s3.amazonaws.com/dd-agent/libyaml-#{version}-x64-windows.tar.lzma",
+source :url => "https://s3.amazonaws.com/dd-agent-omnibus/libyaml-#{version}-x64-windows.zip",
        :extract => :seven_zip
 
 build do
@@ -42,7 +42,7 @@ build do
   # First extract the tar file out of lzma archive.
   command "7z.exe x #{project_file} -o#{temp_directory} -r -y"
   # Now extract the files out of tar archive.
-  command "7z.exe x #{File.join(temp_directory, "libyaml-#{version}-x64-windows.tar")} -o#{temp_directory} -r -y"
+  command "7z.exe x #{File.join(temp_directory, "libyaml-#{version}-x64-windows.zip")} -o#{temp_directory} -r -y"
   # Now copy over libyaml-0-2.dll to the build dir
   copy("#{temp_directory}/bin/libyaml-0-2.dll", "#{install_dir}/embedded/bin/libyaml-0-2.dll")
 end

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -16,21 +16,24 @@
 #
 
 name "libyaml"
-default_version "8a2d1e93b2a2"
+default_version "0.2.2"
 
-source :url => "https://bitbucket.org/xi/libyaml/get/#{version}.tar.gz",
-       :md5 => "601fbd125721460eee302d7d8b058434",
-       :extract => :seven_zip
+source url: "https://pyyaml.org/download/libyaml/yaml-#{version}.tar.gz"
+source sha256: "4a9100ab61047fd9bd395bcef3ce5403365cafd55c1e0d0299cde14958e47be9"
 
-relative_path "xi-libyaml-#{version}"
+relative_path "yaml-#{version}"
+
+dependency "config_guess"
 
 env = with_embedded_path()
 env = with_standard_compiler_flags(env)
 
 build do
   ship_license "https://raw.githubusercontent.com/yaml/libyaml/master/LICENSE"
-  command "./bootstrap"
-  command "./configure --prefix=#{install_dir}/embedded", :env => env
-  command "make -j #{workers}", :env => env
-  command "make -j #{workers} install", :env => env
+
+  update_config_guess(target: "config")
+
+  command "./configure --enable-shared --prefix=#{install_dir}/embedded", :env => env
+  command "make -j #{workers}", env: env
+  command "make -j #{workers} install", env: env
 end


### PR DESCRIPTION
0.2.2 is the version that was released together with our current version of pyyaml, as per [1]

[1] https://pyyaml.org/