### PR TITLE
[unixodbc] Ship license that's shipped with the source

### DIFF
--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -7,8 +7,10 @@ end
 
 source :url => "https://downloads.sourceforge.net/unixodbc/unixODBC-#{version}.tar.gz"
 
+relative_path "unixODBC-#{version}"
+
 build do
-  ship_license "LGPLv2"
+  ship_license "./COPYING"
   env = with_standard_compiler_flags(with_embedded_path)
 
   configure_args = [
@@ -20,7 +22,7 @@ build do
 
   configure_command = configure_args.unshift("./configure").join(" ")
 
-  command configure_command, cwd: "#{Omnibus::Config.source_dir}/unixodbc/unixODBC-#{version}", env: env, in_msys_bash: true
-  make env: env, cwd: "#{Omnibus::Config.source_dir}/unixodbc/unixODBC-#{version}"
-  make "install", cwd: "#{Omnibus::Config.source_dir}/unixodbc/unixODBC-#{version}", env: env
+  command configure_command, env: env, in_msys_bash: true
+  make env: env
+  make "install", env: env
 end


### PR DESCRIPTION
Instead of trying to pull it from a remote website that may be
unavailable.

Also, simplify the software definition by using a relative_path instead
of copy-pasting the working directory to run commands from.
