### PR TITLE
[libffi] Fix include copy

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -61,6 +61,6 @@ build do
   end
 
   # libffi's default install location of header files is awful...
-  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"
+  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
 
 end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -61,6 +61,7 @@ build do
   end
 
   # libffi's default install location of header files is awful...
+  mkdir "#{install_dir}/embedded/include"
   copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
 
 end


### PR DESCRIPTION
### What does this PR do?

If the `#{install_dir}/embedded/include` directory does not exist before (for example, because no dependency ever creates it), then the line:

```
copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include"
```

Takes every file in `#{install_dir}/embedded/lib/libffi-#{version}/include/*` one by one, and copy them in a file named `include` in `#{install_dir}/embedded`.

The end result is that we have one file named `include`, with the contents of the last file matched by `#{install_dir}/embedded/lib/libffi-#{version}/include/*`, while we wanted all files matched to be present in the `include` directory.

### Motivation

A software definition should generally not depend on behaviour that is not guaranteed by their dependencies (or by non-dependecies which usually run before it by coincidence).

MacOS build broke because of this.