### PR TITLE
Bump openssl to 1.0.2t

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,22 +24,19 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 
-default_version "1.0.2o"
+default_version "1.0.2t"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.0.2t") { source sha256: "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc" }
 version("1.0.2o") { source sha256: "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" }
 version("1.0.2k") { source sha256: "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" }
 version("1.0.2j") { source sha256: "e7aff292be21c259c6af26469c7a9b3ba26e9abaaffd325e3dccc9785256c431" }
 version("1.0.2i") { source sha256: "9287487d11c9545b6efb287cdb70535d4e9b284dd10d51441d9b9963d000de6f" }
 version("1.0.2h") { source sha256: "1d4007e53aad94a5b2002fe045ee7bb0b3d98f1a47f8b2bc851dcd1c74332919" }
-version("1.0.2g") { source md5: "f3c710c045cdee5fd114feb69feba7aa" }
 version("1.0.1u") { source sha256: "4312b4ca1215b6f2c97007503d80db80d5157f76f8f7d3febbe6b4c56ff26739" }
-version("1.0.1t") { source md5: "9837746fcf8a6727d46d22ca35953da1" }
-version("1.0.1s") { source md5: "562986f6937aabc7c11a6d376d8a0d26" }
-version("1.0.1r") { source md5: "1abd905e079542ccae948af37e393d28" }
 
 relative_path "openssl-#{version}"
 


### PR DESCRIPTION
Bump openssl to latest 1.0.2 version. Also, remove earlier versions with md5 hashsums.

1.0.2 will be EOL at the end of the year (Dec 31, 2019), so scheduling work to bump to the latest 1.1.1 release before then. According to the [python 2.7.17 release notes](https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.17rc1.rst) there are known issues with building python 2.7 < 2.7.17 against openssl 1.1.1, so I'll schedule this work at the same time as the upgrade to python 2.7.17.

Going to trigger a `datadog-agent` pipeline against this branch to make sure everything builds fine.