### PR TITLE
Update to Python 2.7.17

### DIFF
--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -18,7 +18,7 @@
 name "python"
 
 if ohai["platform"] != "windows"
-  default_version "2.7.16"
+  default_version "2.7.17"
 
   dependency "ncurses"
   dependency "zlib"
@@ -27,7 +27,7 @@ if ohai["platform"] != "windows"
   dependency "libsqlite3"
 
   source :url => "http://python.org/ftp/python/#{version}/Python-#{version}.tgz",
-         :sha256 => "01da813a3600876f03f46db11cc5c408175e99f03af2ba942ef324389a83bad5"
+         :sha256 => "f22059d09cdf9625e0a7284d24a13062044f5bf59d93a7f3382190dfa94cecde"
 
   relative_path "Python-#{version}"
 
@@ -67,14 +67,14 @@ if ohai["platform"] != "windows"
   end
 
 else
-  default_version "2.7.16"
+  default_version "2.7.17"
 
   dependency "vc_redist"
   dependency "vc_python"
 
   msi_name = "python-#{version}.amd64.msi"
   source :url => "https://www.python.org/ftp/python/#{version}/#{msi_name}",
-         :sha256 => "7c0f45993019152d46041a7db4b947b919558fdb7a8f67bcd0535bc98d42b603"
+         :sha256 => "3b934447e3620e51d2daf5b2f258c9b617bcc686ca2f777a49aa3b47893abf1b"
 
   build do
     # In case Python is already installed on the build machine well... let's uninstall it


### PR DESCRIPTION
Bump Python version to 2.7.16

2 fixed CVEs are mentioned there: https://github.com/python/cpython/blob/2.7/Misc/NEWS.d/2.7.17rc1.rst.

Check agent 5 with a custom build on Ubuntu and Windows: OK