### PR TITLE
Update unixodbc version to 2.3.7

### DIFF
--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -1,8 +1,8 @@
 name "unixodbc"
-default_version "2.3.4"
+default_version "2.3.7"
 
-version "2.3.4" do
-  source :sha256 => "2e1509a96bb18d248bf08ead0d74804957304ff7c6f8b2e5965309c632421e39"
+version "2.3.7" do
+  source :sha256 => "d4d4dd039e0cc4d8ae7a0b0d09c25630521cf616921ec8c9293734ba70988fbc"
 end
 
 source :url => "https://downloads.sourceforge.net/unixodbc/unixODBC-#{version}.tar.gz"

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -2,10 +2,10 @@ name "unixodbc"
 default_version "2.3.7"
 
 version "2.3.7" do
-  source :sha256 => "d4d4dd039e0cc4d8ae7a0b0d09c25630521cf616921ec8c9293734ba70988fbc"
+  source :sha256 => "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77"
 end
 
-source :url => "https://downloads.sourceforge.net/unixodbc/unixODBC-#{version}.tar.gz"
+source :url => "ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-#{version}.tar.gz"
 
 relative_path "unixODBC-#{version}"
 

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -5,7 +5,7 @@ version "2.3.7" do
   source :sha256 => "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77"
 end
 
-source :url => "ftp://ftp.unixodbc.org/pub/unixODBC/unixODBC-#{version}.tar.gz"
+source :url => "http://www.unixodbc.org/unixODBC-#{version}.tar.gz"
 
 relative_path "unixODBC-#{version}"
 


### PR DESCRIPTION
Upgrade unixodbc to 2.3.7 mainly address [CVE-2018-7409](https://access.redhat.com/security/cve/cve-2018-7409)

`unixodbc` change log: https://fossies.org/linux/unixODBC/ChangeLog

Use `http://www.unixodbc.org` instead of `https://downloads.sourceforge.net`. Reason: Source forge version of 2.3.7 is a `pre` version "unixODBC-2.3.7pre.tar.gz". The hash is different. Most sources suggest to download via `http://www.unixodbc.org`.

# QA NOTES

TLDR, works on docker agent & debian.

On AGENT 6.15.0~rc.1-1
```
$ strings /opt/datadog-agent/embedded/lib/libodbc.so.2 | grep '2.3'
GLIBC_2.3
$2.3.fA
2.3.4
```

On AGENT 7.17.0 custom build with unixodbc 2.3.7 installed
```
strings /opt/datadog-agent/embedded/lib/libodbc.so.2 | grep '2.3'
GLIBC_2.3
$2.3.fA
2.3.7
```

unixodbc 2.3.7 working fine with sqlserver See QA [Pipelines](https://dev.azure.com/datadoghq/integrations-core/_build/results?buildId=5386&view=logs&j=910f82a4-622d-5ace-f877-8b75c045486c&t=66e8cc47-ff40-5964-82bf-b24377b9a6cd)
* For docker agent py2 and py3 using e2e tests


Works on debian with unixodbc 2.3.7  and 

```
    sqlserver (1.14.0)
    ------------------
      Instance ID: sqlserver:588d528f1739085e [OK]
      Configuration Source: file:/etc/datadog-agent/conf.d/sqlserver.d/sqlserver.yaml
      Total Runs: 1
      Metric Samples: Last Run: 17, Total: 17
      Events: Last Run: 0, Total: 0
      Service Checks: Last Run: 1, Total: 1
      Average Execution Time : 10ms
```

QA PRs
- https://github.com/DataDog/integrations-core/pull/5285
- https://github.com/DataDog/datadog-agent/pull/4652

