### PR TITLE
Upgrading procps-ng, autoconf and curl versions

### DIFF
--- a/config/software/autoconf.rb
+++ b/config/software/autoconf.rb
@@ -16,14 +16,14 @@
 #
 
 name "autoconf"
-default_version "2.68"
+default_version "2.69"
 
 dependency "config_guess"
 
-source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-2.68.tar.gz",
-       md5: "c3b5247592ce694f7097873aa07d66fe"
+source url: "http://ftp.gnu.org/gnu/autoconf/autoconf-#{version}.tar.gz",
+       md5: "82d05e03b93e45f5a39b828dc9c6c29b"
 
-relative_path "autoconf-2.68"
+relative_path "autoconf-2.69"
 
 env = {
   "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -16,13 +16,13 @@
 #
 
 name "curl"
-default_version "7.65.3"
+default_version "7.66.0"
 
 dependency "zlib"
 dependency "openssl"
 dependency "nghttp2"
-source url: "https://curl.haxx.se/download/curl-#{version}.tar.gz",
-       sha256: "4376ac72b95572fb6c4fbffefb97c7ea0dd083e1974c0e44cd7e49396f454839"
+source url:    "https://curl.haxx.se/download/curl-#{version}.tar.gz",
+       sha256: "d0393da38ac74ffac67313072d7fe75b1fa1010eb5987f63f349b024a36b7ffb"
 
 relative_path "curl-#{version}"
 

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -25,7 +25,7 @@ build do
     f.puts "#{version}"
   end
 
-  command("./autogen.sh", :env: env)
+  command("./autogen.sh", env: env)
   command(["./configure",
            "--prefix=#{install_dir}/embedded",
            "--without-ncurses",

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -1,12 +1,12 @@
 name "procps-ng"
-default_version "3.3.9"
+default_version "3.3.16"
 
 ship_source true
 
-source url: "http://dd-agent-omnibus.s3.amazonaws.com/#{name}-#{version}.tar.xz",
-       md5: "0980646fa25e0be58f7afb6b98f79d74"
+source url:    "https://gitlab.com/procps-ng/procps/-/archive/v3.3.16/procps-v#{version}.tar.gz",
+       sha256: "7f09945e73beac5b12e163a7ee4cae98bcdd9a505163b6a060756f462907ebbc"
 
-relative_path "procps-ng-3.3.9"
+relative_path "procps-v#{version}"
 
 env = {
   "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
@@ -16,6 +16,16 @@ env = {
 
 build do
   ship_license "https://gitlab.com/procps-ng/procps/raw/master/COPYING"
+
+  # By default procps-ng will build with the 'UNKNOWN' version if not built
+  # from a git repository and the '.tarball-version' file doesn't exist.
+  # Setting the version in that file will allow binaries to return the correct
+  # info from the '--version' command.
+  File.open(".tarball-version", "w") do |f|
+    f.puts "#{version}"
+  end
+
+  command("./autogen.sh", :env: env)
   command(["./configure",
            "--prefix=#{install_dir}/embedded",
            "--without-ncurses",
@@ -23,6 +33,4 @@ build do
     env: env)
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
-  move "#{install_dir}/embedded/usr/bin/*", "#{install_dir}/embedded/bin/"
-  delete "#{install_dir}/embedded/usr/bin"
 end


### PR DESCRIPTION
- Upgrading curl to 7.66.0
- Upgrading autoconf to 2.69
- Upgrading procps-ng to 3.3.16