### PR TITLE
[CI] Upgrade ruby version to 2.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-rvm: 2.1
+rvm: 2.3
 
 branches:
   only:


### PR DESCRIPTION
### What does this PR do?

Upgrades the ruby version used in travis to 2.3 (the version we use to build the Agent).

### Motivation

A recent omnibus-ruby refactor broke compatibility with EOL ruby 2.1, and it's better to use the ruby version that's actually used in the main Agent repo.