### PR TITLE
[A5] Bump openssl to 1.1.1 and pyopenssl to 19.0.0

### DIFF
--- a/config/patches/openssl/openssl-1.1.1d-do-not-build-docs.patch
+++ b/config/patches/openssl/openssl-1.1.1d-do-not-build-docs.patch
@@ -1,0 +1,11 @@
+--- openssl-1.1.1d/Makefile	2020-01-17 13:39:02.252815253 -0700
++++ openssl-1.1.1d/Makefile	2020-01-17 13:39:18.224704427 -0700
+@@ -223,7 +223,7 @@
+ 	 $(PERL) $(SRCDIR)/test/run_tests.pl list
+ 	@ : 
+ 
+-install: install_sw install_ssldirs install_docs
++install: install_sw install_ssldirs
+ 
+ uninstall: uninstall_docs uninstall_sw
+ 

--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -1,5 +1,5 @@
 name "cryptography"
-default_version "2.3"
+default_version "2.8"
 
 dependency "python"
 dependency "pip"

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -1,6 +1,6 @@
 name "pyopenssl"
 # If you upgrade pyopenssl, you'll probably have to upgrade `cryptography` as well
-default_version "17.5.0"
+default_version "19.0.0"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
We need to bump pyopenssl in order to be compatible with openssl 1.1.1.