### PR TITLE
[A5] Bump openssl to 1.1

### DIFF
--- a/config/patches/openssl/openssl-1.1.1d-do-not-build-docs.patch
+++ b/config/patches/openssl/openssl-1.1.1d-do-not-build-docs.patch
@@ -1,0 +1,11 @@
+--- openssl-1.1.1d/Makefile	2020-01-17 13:39:02.252815253 -0700
++++ openssl-1.1.1d/Makefile	2020-01-17 13:39:18.224704427 -0700
+@@ -223,7 +223,7 @@
+ 	 $(PERL) $(SRCDIR)/test/run_tests.pl list
+ 	@ : 
+ 
+-install: install_sw install_ssldirs install_docs
++install: install_sw install_ssldirs
+ 
+ uninstall: uninstall_docs uninstall_sw
+ 

--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -1,5 +1,5 @@
 name "cryptography"
-default_version "2.3"
+default_version "2.8"
 
 dependency "python"
 dependency "pip"

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -120,7 +120,7 @@ build do
 
       patch_env = env.dup
       patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}"
-      patch source: patch_file, env: patch_env
+      patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
     else
       patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: env
     end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,12 +24,13 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 
-default_version "1.0.2t"
+default_version "1.1.1d"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
 version("1.0.2t") { source sha256: "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc" }
 version("1.0.2o") { source sha256: "ec3f5c9714ba0fd45cb4e087301eb1336c317e0d20b575a125050470e8089e4d" }
 version("1.0.2k") { source sha256: "6b3977c61f2aedf0f96367dcfb5c6e578cf37e7b8d913b4ecb6643c3cb88d8c0" }
@@ -110,22 +111,24 @@ build do
       "#{prefix} disable-gost"
     end
 
-  if aix?
+  # on 1.0 we have to path before running config
+  if version.start_with? "1.0."
+    if aix?
+      # This enables omnibus to use 'makedepend'
+      # from fileset 'X11.adt.imake' (AIX install media)
+      env["PATH"] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
 
-    # This enables omnibus to use 'makedepend'
-    # from fileset 'X11.adt.imake' (AIX install media)
-    env["PATH"] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+      patch_env = env.dup
+      patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}"
+      patch source: patch_file, env: patch_env
+    else
+      patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: env
+    end
 
-    patch_env = env.dup
-    patch_env["PATH"] = "/opt/freeware/bin:#{env['PATH']}"
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: patch_env
-  else
-    patch source: "openssl-1.0.1f-do-not-build-docs.patch", env: env
-  end
-
-  if windows?
-    # Patch Makefile.org to update the compiler flags/options table for mingw.
-    patch source: "openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch", env: env
+    if windows?
+      # Patch Makefile.org to update the compiler flags/options table for mingw.
+      patch source: "openssl-1.0.1q-fix-compiler-flags-table-for-msys.patch", env: env
+    end
   end
 
   # Out of abundance of caution, we put the feature flags first and then
@@ -135,6 +138,22 @@ build do
   configure_command = configure_args.unshift(configure_cmd).join(" ")
 
   command configure_command, env: env, in_msys_bash: true
+
+  # on 1.1 we have to path after running config
+  if version.start_with? "1.1."
+    if aix?
+      # This enables omnibus to use 'makedepend'
+      # from fileset 'X11.adt.imake' (AIX install media)
+      env["PATH"] = "/usr/lpp/X11/bin:#{ENV["PATH"]}"
+
+      patch_env = env.dup
+      patch_env["PATH"] = "/opt/freeware/bin:#{env["PATH"]}"
+      patch source: "openssl-1.1.1d-do-not-build-docs.patch", env: patch_env
+    else
+      patch source: "openssl-1.1.1d-do-not-build-docs.patch", env: env
+    end
+  end
+
   make "depend", env: env
   # make -j N on openssl is not reliable
   make env: env

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -16,10 +16,10 @@
 #
 
 name "postgresql"
-default_version "9.2.8"
+default_version "9.4.25"
 
 dependency "zlib"
-dependency "openssl"
+dependency "openssl" # openssl >= 1.1 is compatible with postgresql >=9.4
 dependency "libedit"
 dependency "ncurses"
 
@@ -35,7 +35,13 @@ version "9.3.4" do
   source :md5 => "d0a41f54c377b2d2fab4a003b0dac762"
 end
 
-source :url => "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+# Version lower than 9.4 aren't compatible with openssl 1.1
+# (9.4.12 for openssl 1.1.0 and 9.4.24 for visual studio)
+version "9.4.25" do
+  source md5: "5b8270dfd9a074088d3508836584260e"
+end
+
+source url: "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 relative_path "postgresql-#{version}"
 
 configure_env = {

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -1,6 +1,6 @@
 name "pyopenssl"
 # If you upgrade pyopenssl, you'll probably have to upgrade `cryptography` as well
-default_version "17.5.0"
+default_version "19.0.0"
 
 dependency "python"
 dependency "pip"


### PR DESCRIPTION
This PR is on hold until we figure out the centos 5 build issue (ie: openssl 1.1 requires perl 5.10 which is not available on centos5)