### PR TITLE
Bump sqlite version from 3.7.7.1 to 3.31.1

### DIFF
--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -1,11 +1,12 @@
 name "libsqlite3"
-default_version "3.7.7.1"
+default_version "3.31.1"
 
 dependency "config_guess"
 
-source git: "git://github.com/LuaDist/libsqlite3.git"
+source url: "https://www.sqlite.org/2020/sqlite-autoconf-3310100.tar.gz",
+       sha256: "62284efebc05a76f909c580ffa5c008a7d22a1287285d68b7825a2b6b51949ae"
 
-relative_path "libsqlite3"
+relative_path "sqlite-autoconf-3310100"
 
 env = {
   "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",


### PR DESCRIPTION
For CVE-2019-5018 and CVE-2019-19603

I don't really know why we were not relying on official sqlite repository, but I don't really know if there is another valid location with the latest source code.