### PR TITLE
[openssl] Bump to 1.1.1h

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -24,7 +24,7 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless aix? || windows?
 
-default_version "1.1.1f"
+default_version "1.1.1h"
 
 # OpenSSL source ships with broken symlinks which windows doesn't allow.
 # Skip error checking.
@@ -32,11 +32,12 @@ default_version "1.1.1f"
 # Note: Since April 2020, only the most recent version of openssl is
 # available at https://www.openssl.org/source/.
 # Older versions of openssl are now there: https://www.openssl.org/source/old/
-# Expect this software definition to break every time openssl is updated.
+# This software definition may break every time openssl is updated.
 # To build with an older version of openssl, you'll need to update the source url to
 # https://www.openssl.org/source/old/<bugfix_version>/openssl-<full_version>.tar.gz
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
+version("1.1.1h") { source sha256: "5c9ca8774bd7b03e5784f26ae9e9e6d749c9da2438545077e6b3d755a06595d9" }
 version("1.1.1f") { source sha256: "186c6bfe6ecfba7a5b48c47f8a1673d0f3b0e5ba2e25602dd23b629975da3f35" }
 version("1.1.1d") { source sha256: "1e3a91bc1f9dfce01af26026f856e064eab4c8ee0a8f457b5ae30b40b8b711f2" }
 version("1.0.2t") { source sha256: "14cb464efe7ac6b54799b34456bd69558a749a4931ecfd9cf9f71d7881cac7bc" }


### PR DESCRIPTION
Motivation: none in particular, simply noticed that we weren't shipping the latest `1.1.1` version. Let' ship it for 7.25.

Also updated the comment (the link doesn't necessarily seem to break on every openssl release, it didn't this time typically).

A `datadog-agent` gitlab pipeline using this branch works (see pipeline id `3469469`). The `build-system-probe-arm64` fails but seems to fail on master as well at the moment, so very likely not related to this change.