### PR TITLE
[libsqlite3] Bump version to 3.35.5

### DIFF
--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -1,12 +1,12 @@
 name "libsqlite3"
-default_version "3.33.0"
+default_version "3.35.5"
 
 dependency "config_guess"
 
-source url: "https://www.sqlite.org/2020/sqlite-autoconf-3330000.tar.gz",
-       sha256: "106a2c48c7f75a298a7557bcc0d5f4f454e5b43811cc738b7ca294d6956bbb15"
+source url: "https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz",
+       sha256: "f52b72a5c319c3e516ed7a92e123139a6e87af08a2dc43d7757724f6132e6db0"
 
-relative_path "sqlite-autoconf-3330000"
+relative_path "sqlite-autoconf-3350500"
 
 env = {
   "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",


### PR DESCRIPTION
To fix a [CVE](https://nvd.nist.gov/vuln/detail/CVE-2021-20227) that we shouldn't be affected by, but that shows up in scanners