### PR TITLE
[unixodbc] Delete empty example files

### DIFF
--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -26,6 +26,8 @@ build do
   make env: env
   make "install", env: env
 
+  # Remove the sample (empty) files unixodbc adds, otherwise they will replace
+  # any user-added configuration on upgrade.
   delete "#{install_dir}/embedded/etc/odbc.ini"
   delete "#{install_dir}/embedded/etc/odbcinst.ini"
 

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -25,4 +25,21 @@ build do
   command configure_command, env: env, in_msys_bash: true
   make env: env
   make "install", env: env
+
+  delete "#{install_dir}/embedded/etc/odbc.ini"
+  delete "#{install_dir}/embedded/etc/odbcinst.ini"
+
+  # Add a section to the README
+  block do
+    File.open(File.expand_path(File.join(install_dir, "/embedded/etc/README.md")), "a") do |f|
+      f.puts <<~EOF
+          ## unixODBC
+
+          To add unixODBC data sources that can be used by the Agent embedded environment,
+          add `odbc.ini` and `odbcinst.ini` files to this folder, containing the data sources'
+          configuration.
+
+      EOF
+    end
+  end
 end


### PR DESCRIPTION
### What does this PR do?

Removes empty example files that unixodbc places in the embedded directory. On upgrade, these empty files would replace any configuration set by the user.
Adds a section in the `embedded/etc/README.md` file about unixodbc config files.