### PR TITLE
[gohai] manually get correct tag, don't go get -u

### DIFF
--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -20,9 +20,9 @@ build do
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
   # Checkout gohai's deps
-  command "#{gobin} get -u github.com/shirou/gopsutil", :env => env
+  command "#{gobin} get -d github.com/shirou/gopsutil", :env => env
   command "git checkout v2.0.0", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/shirou/gopsutil"
-  command "#{gobin} get -u github.com/cihub/seelog", :env => env
+  command "#{gobin} get -d github.com/cihub/seelog", :env => env
   command "git checkout v2.6", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/cihub/seelog"
   # Windows depends on the registry, go get that.
   if ohai["platform"] == "windows"


### PR DESCRIPTION
The `go get -u` pattern was causing build issues, we can just get, and then `git checkout` to the correct tag.  