### PR TITLE
Add note about why we ship cacerts

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -14,6 +14,12 @@
 # limitations under the License.
 #
 
+# Note: we need to bundle recent cacerts to make the Agent trust our backend.
+# Not shipping the cacerts causes the following error in the Docker Agent:
+#   Error while processing transaction: error while sending transaction, rescheduling it:
+#   Post "https://7-31-0-app.agent.datadoghq.com/intake/?api_key=********************************":
+#   x509: certificate signed by unknown authority
+# because the Docker Agent image doesn't have other system SSL certificates.
 name "cacerts"
 
 # We have a synthetic monitor on the latest cacerts file to warn us when the latest

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -20,6 +20,9 @@
 #   Post "https://7-31-0-app.agent.datadoghq.com/intake/?api_key=********************************":
 #   x509: certificate signed by unknown authority
 # because the Docker Agent image doesn't have other system SSL certificates.
+# Even though these cacerts might become outdated in the future, some python
+# dependencies we ship also bundle cacerts so we aren't making things worse by
+# doing this.
 name "cacerts"
 
 # We have a synthetic monitor on the latest cacerts file to warn us when the latest


### PR DESCRIPTION
### What does this PR do?

Add one explanation to why we need to ship cacerts in the datadog-agent package, so that we have an answer ready the next time we ask ourselves why we're shipping them.
There may be other cases where they're needed, they'll be added here when we find them.