### PR TITLE
[licensing] Use license & license_file DSL

### DIFF
--- a/config/software/asn1crypto.rb
+++ b/config/software/asn1crypto.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://github.com/wbond/asn1crypto/blob/master/LICENSE"
+  license "MIT"
+  license_file "https://github.com/wbond/asn1crypto/blob/master/LICENSE"
   pip "install asn1crypto==#{version}"
 end

--- a/config/software/boto.rb
+++ b/config/software/boto.rb
@@ -4,6 +4,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/boto/boto/develop/LICENSE"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/boto/boto/develop/LICENSE"
   pip "install #{name}==#{version}"
 end

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -41,7 +41,8 @@ env = {
 }
 
 build do
-  ship_license "https://sourceware.org/git/?p=bzip2.git;a=blob_plain;f=LICENSE;h=81a37eab7a5be1a34456f38adb74928cc9073e9b;hb=HEAD"
+  license "BSD-style"
+  license_file "https://sourceware.org/git/?p=bzip2.git;a=blob_plain;f=LICENSE;h=81a37eab7a5be1a34456f38adb74928cc9073e9b;hb=HEAD"
   patch source: "makefile_take_env_vars.patch"
   patch source: "soname_install_dir.patch" if ohai["platform_family"] == "mac_os_x"
   command "make PREFIX=#{prefix} VERSION=#{version}", env: env

--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -37,7 +37,8 @@ source url: "https://curl.se/ca/cacert-#{version}.pem",
 relative_path "cacerts-#{version}"
 
 build do
-  ship_license "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
+  license "MPL-2.0"
+  license_file "https://www.mozilla.org/media/MPL/2.0/index.815ca599c9df.txt"
 
   if windows?
     if with_python_runtime? "2"

--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -9,6 +9,7 @@ dependency "openssl"
 dependency "asn1crypto"
 
 build do
-  ship_license "https://github.com/pyca/cryptography/blob/master/LICENSE.APACHE"
+  license "Apache-2.0"
+  license_file "https://github.com/pyca/cryptography/blob/master/LICENSE.APACHE"
   pip "install cryptography==#{version}"
 end

--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -27,7 +27,8 @@ source url:    "https://curl.haxx.se/download/curl-#{version}.tar.gz",
 relative_path "curl-#{version}"
 
 build do
-  ship_license "https://raw.githubusercontent.com/bagder/curl/master/COPYING"
+  license "Curl"
+  license_file "https://raw.githubusercontent.com/bagder/curl/master/COPYING"
   block do
     FileUtils.rm_rf(File.join(project_dir, "src/tool_hugehelp.c"))
   end

--- a/config/software/cython.rb
+++ b/config/software/cython.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/cython/cython/master/LICENSE.txt"
+  license "Apache-2.0"
+  license_file "https://raw.githubusercontent.com/cython/cython/master/LICENSE.txt"
   command "#{install_dir}/embedded/bin/pip install --install-option=\"--no-cython-compile\" cython==#{version}"
 end

--- a/config/software/datadog-a7-py2.rb
+++ b/config/software/datadog-a7-py2.rb
@@ -4,7 +4,8 @@ default_version "0.0.5"
 dependency "pip-py2"
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
   py2pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version} "\

--- a/config/software/datadog-a7-py3.rb
+++ b/config/software/datadog-a7-py3.rb
@@ -4,7 +4,8 @@ default_version "0.0.5"
 dependency "pip-py3"
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
   py3pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version} "\

--- a/config/software/datadog-a7.rb
+++ b/config/software/datadog-a7.rb
@@ -4,7 +4,8 @@ default_version "0.0.5"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/DataDog/datadog-checks-shared/master/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version} "\

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -17,8 +17,9 @@ else
 end
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
-  ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
+  license_file "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
   # Checkout gohai's deps
   command "#{gobin} get -u github.com/shirou/gopsutil", env: env
   command "git checkout v2.0.0", env: env, cwd: "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/shirou/gopsutil"

--- a/config/software/datadog-metro.rb
+++ b/config/software/datadog-metro.rb
@@ -27,8 +27,9 @@ else
 end
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/go-metro/master/LICENSE"
-  ship_license "https://raw.githubusercontent.com/DataDog/go-metro/master/THIRD_PARTY_LICENSES.md"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/DataDog/go-metro/master/LICENSE"
+  license_file "https://raw.githubusercontent.com/DataDog/go-metro/master/THIRD_PARTY_LICENSES.md"
 
   if ohai["platform_family"] == "rhel"
     command "mv gometro-centos6-#{version} #{install_dir}/bin/go-metro.bin"

--- a/config/software/datadogpy.rb
+++ b/config/software/datadogpy.rb
@@ -5,7 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/datadogpy/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/DataDog/datadogpy/master/LICENSE"
   # We use `pip install` w/o the `-I` option here because we don't want pip to ignore the deps that have
   # already been installed (for instance `requests`), as it could make pip potentially install a different version of the the dep
   pip "install --install-option=\"--install-scripts=#{install_dir}/bin\" datadog==#{version}"

--- a/config/software/distro.rb
+++ b/config/software/distro.rb
@@ -5,7 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/nir0s/distro/master/LICENSE"
+  license "Apache-2.0"
+  license_file "https://raw.githubusercontent.com/nir0s/distro/master/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/docker-py.rb
+++ b/config/software/docker-py.rb
@@ -5,7 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "Apachev2"
+  license "Apache-2.0"
   # Don't use --install-option to specify the scripts path, as this disables wheels, and one of the
   # docker-py deps (pywin32) can only be installed with a wheel
   pip "install #{name}==#{version}"

--- a/config/software/futures.rb
+++ b/config/software/futures.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/agronholm/pythonfutures/master/LICENSE"
+  license "Python-2.0"
+  license_file "https://raw.githubusercontent.com/agronholm/pythonfutures/master/LICENSE"
   pip "install --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\" #{name}==#{version}"
 end

--- a/config/software/jmxterm.rb
+++ b/config/software/jmxterm.rb
@@ -11,7 +11,8 @@ source url: "https://dd-jmxfetch.s3.amazonaws.com/jmxterm-#{version}-DATADOG-ube
 relative_path "jmxterm"
 
 build do
-  ship_license "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/DataDog/jmxfetch/master/LICENSE"
   mkdir "#{install_dir}/agent/checks/libs"
   copy "jmxterm-*-DATADOG-uber.jar", "#{install_dir}/agent/checks/libs"
 end

--- a/config/software/kazoo.rb
+++ b/config/software/kazoo.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "Apachev2"
+  license "Apache-2.0"
   pip "install --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\" #{name}==#{version}"
 end

--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -57,7 +57,8 @@ env = case ohai["platform"]
       end
 
 build do
-  ship_license "https://gist.githubusercontent.com/remh/d001e1be55cd07a88550/raw/742f005f8f9c744a4c7c8b2a0e6c3018546d6d0c/libedit.LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://gist.githubusercontent.com/remh/d001e1be55cd07a88550/raw/742f005f8f9c744a4c7c8b2a0e6c3018546d6d0c/libedit.LICENSE"
   # The patch is from the FreeBSD ports tree and is for GCC compatibility.
   # http://svnweb.freebsd.org/ports/head/devel/libedit/files/patch-vi.c?annotate=300896
   if ohai["platform"] == "freebsd"

--- a/config/software/libgcc.rb
+++ b/config/software/libgcc.rb
@@ -38,6 +38,8 @@ libgcc_file =
   end
 
 build do
+  license "GPL-3.0"
+
   if libgcc_file
     if File.exist?(libgcc_file)
       copy "#{libgcc_file}", "#{install_dir}/embedded/lib/"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -55,6 +55,10 @@ if ohai["platform"] == "solaris2"
 end
 
 build do
+  license "LGPL-2.1"
+  license_file "./COPYING"
+  license_file "./COPYING.lib"
+
   patch source: "libiconv-1.14_srclib_stdio.in.h-remove-gets-declarations.patch"
   update_config_guess(target: "build-aux")
   update_config_guess(target: "libcharset/build-aux")

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -24,6 +24,8 @@ source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
 relative_path "xz-#{version}"
 
 build do
+  license "Public-Domain"
+
   cmd = [ "./configure",
           "--prefix=#{install_dir}/embedded",
           "--disable-debug",

--- a/config/software/libpcap.rb
+++ b/config/software/libpcap.rb
@@ -35,7 +35,8 @@ env = with_standard_compiler_flags
 env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
 build do
-  ship_license "https://gist.githubusercontent.com/truthbk/b06f2ea54f6f297c599e/raw/e1fc035d3114cd43e55fabcddd073e20307c129e/libpcap.license"
+  license "BSD-3-Clause"
+  license_file "https://gist.githubusercontent.com/truthbk/b06f2ea54f6f297c599e/raw/e1fc035d3114cd43e55fabcddd073e20307c129e/libpcap.license"
   command "./configure --prefix=#{install_dir}/embedded", env: env
   command "make -j #{workers}", env: env
   command "make -j #{workers} install", env: env

--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -15,6 +15,8 @@ env = {
 }
 
 build do
+  license "Public-Domain"
+
   update_config_guess
   command(["./configure",
        "--prefix=#{install_dir}/embedded",

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -17,8 +17,6 @@
 name "libtool"
 default_version "2.4"
 
-license "GPL-2.0"
-license_file "COPYING"
 skip_transitive_dependency_licensing true
 
 dependency "config_guess"
@@ -33,6 +31,9 @@ source url: "https://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
 relative_path "libtool-#{version}"
 
 build do
+  license "GPL-2.0"
+  license_file "./COPYING"
+
   env = with_standard_compiler_flags(with_embedded_path)
 
   update_config_guess

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -29,7 +29,8 @@ env = with_embedded_path
 env = with_standard_compiler_flags(env)
 
 build do
-  ship_license "https://raw.githubusercontent.com/yaml/libyaml/master/License"
+  license "MIT"
+  license_file "./LICENSE"
 
   update_config_guess(target: "config")
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -24,6 +24,7 @@ source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0
 
 relative_path "makedepend-1.0.5"
 
+
 dependency "xproto"
 dependency "util-macros"
 dependency "pkg-config"
@@ -65,7 +66,9 @@ configure_env["PKG_CONFIG_PATH"] = "#{install_dir}/embedded/lib/pkgconfig" +
 configure_env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 
 build do
-  ship_license "https://raw.githubusercontent.com/ioerror/makedepend/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/ioerror/makedepend/master/LICENSE"
+
   command "./configure --prefix=#{install_dir}/embedded", env: configure_env
   command "make -j #{workers}", env: configure_env
   command "make -j #{workers} install", env: configure_env

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -47,7 +47,9 @@ env = with_standard_compiler_flags(env, aix: { use_gcc: true })
 ########################################################################
 
 build do
-  ship_license "https://gist.githubusercontent.com/remh/41a4f7433c77841c302c/raw/d15db09a192ca0e51022005bfb4c3a414a996896/ncurse.LICENSE"
+  license "MIT"
+  license_file "https://gist.githubusercontent.com/remh/41a4f7433c77841c302c/raw/d15db09a192ca0e51022005bfb4c3a414a996896/ncurse.LICENSE"
+
   env.delete("CPPFLAGS")
 
   update_config_guess

--- a/config/software/net-snmp-lib.rb
+++ b/config/software/net-snmp-lib.rb
@@ -36,7 +36,8 @@ net_snmp_configure = ["./configure",
                       "--enable-shared",
                       "--disable-static"]
 build do
-  ship_license "https://gist.githubusercontent.com/truthbk/219266c31f7d664c749dba525eb8a7b0/raw/82539d51d5b1e545e1ceb241b25f476956b636f9/net-snmp.license"
+  license "BSD-style"
+  license_file "https://gist.githubusercontent.com/truthbk/219266c31f7d664c749dba525eb8a7b0/raw/82539d51d5b1e545e1ceb241b25f476956b636f9/net-snmp.license"
 
   if mac_os_x?
     copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin14.h"

--- a/config/software/net-snmp.rb
+++ b/config/software/net-snmp.rb
@@ -33,7 +33,8 @@ net_snmp_configure = ["./configure",
                       "--enable-shared",
                       "--disable-static"]
 build do
-  ship_license "https://gist.githubusercontent.com/truthbk/219266c31f7d664c749dba525eb8a7b0/raw/82539d51d5b1e545e1ceb241b25f476956b636f9/net-snmp.license"
+  license "BSD-style"
+  license_file "https://gist.githubusercontent.com/truthbk/219266c31f7d664c749dba525eb8a7b0/raw/82539d51d5b1e545e1ceb241b25f476956b636f9/net-snmp.license"
 
   if mac_os_x?
     copy "include/net-snmp/system/darwin13.h", "include/net-snmp/system/darwin14.h"

--- a/config/software/nfsiostat.rb
+++ b/config/software/nfsiostat.rb
@@ -23,6 +23,8 @@ source git: "git://git.linux-nfs.org/projects/steved/nfs-utils.git"
 relative_path "nfs-utils"
 
 build do
+  license "GPL-2.0"
+
   mkdir "#{install_dir}/embedded/sbin/"
   command "sed -i 's:#!/usr/bin/python:#!/opt/datadog-agent/embedded/bin/python:' ./tools/nfs-iostat/nfs-iostat.py"
   command "cp ./tools/nfs-iostat/nfs-iostat.py #{install_dir}/embedded/sbin/nfsiostat"

--- a/config/software/nghttp2.rb
+++ b/config/software/nghttp2.rb
@@ -16,6 +16,9 @@ env = {
 }
 
 build do
+  license "MIT"
+  license_file "./COPYING"
+
   command [
     "./configure",
     "--disable-app",

--- a/config/software/ntplib.rb
+++ b/config/software/ntplib.rb
@@ -5,7 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "MIT"
+  license "MIT"
   if ohai["platform"] == "windows"
     pip "install "\
         "#{name}==#{version}"

--- a/config/software/pgsql.rb
+++ b/config/software/pgsql.rb
@@ -8,7 +8,8 @@ source url: "http://get.enterprisedb.com/postgresql/postgresql-9.4.4-3-windows-x
        md5: "094d18f3534d1a6c1cab17d37fb88319"
 
 build do
-  ship_license "https://raw.githubusercontent.com/lpsmith/postgresql-libpq/master/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/lpsmith/postgresql-libpq/master/LICENSE"
 
   # After trying to compile unsuccessfully with VisualC++ and MinGW let's stick to the
   # standard windows "solutions" : download the binaries and making a nice copy of it :)

--- a/config/software/pip-py2.rb
+++ b/config/software/pip-py2.rb
@@ -28,7 +28,8 @@ source url: "https://github.com/pypa/pip/archive/#{version}.tar.gz",
 relative_path "pip-#{version}"
 
 build do
-  ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
   if ohai["platform"] == "windows"
     command "\"#{windows_safe_path(python_2_embedded)}\\python.exe\" setup.py install "\
             "--prefix=\"#{windows_safe_path(python_2_embedded)}\""

--- a/config/software/pip-py3.rb
+++ b/config/software/pip-py3.rb
@@ -28,7 +28,8 @@ source url: "https://github.com/pypa/pip/archive/#{version}.tar.gz",
 relative_path "pip-#{version}"
 
 build do
-  ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
   if ohai["platform"] == "windows"
     command "\"#{windows_safe_path(python_3_embedded)}\\python.exe\" setup.py install "\
             "--prefix=\"#{windows_safe_path(python_3_embedded)}\""

--- a/config/software/pip.rb
+++ b/config/software/pip.rb
@@ -28,7 +28,8 @@ source url: "https://github.com/pypa/pip/archive/#{version}.tar.gz",
 relative_path "pip-#{version}"
 
 build do
-  ship_license "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/pypa/pip/develop/LICENSE.txt"
   if ohai["platform"] == "windows"
     command "\"#{windows_safe_path(install_dir)}\\embedded\\python.exe\" setup.py install "\
             "--prefix=\"#{windows_safe_path(install_dir)}\\embedded\""

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -37,6 +37,9 @@ env = with_standard_compiler_flags(env, aix: { use_gcc: true })
 paths = [ "#{install_dir}/embedded/bin/pkgconfig" ]
 
 build do
+  license "GPL-2.0"
+  license_file "./COPYING"
+
   command "./configure --prefix=#{install_dir}/embedded --disable-debug --disable-host-tool --with-internal-glib --with-pc-path=#{paths * ":"}", env: env
   # #203: pkg-configs internal glib does not provide a way to pass ldflags.
   # Only allows GLIB_CFLAGS and GLIB_LIBS.

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -15,7 +15,9 @@ env = {
 }
 
 build do
-  ship_license "https://gitlab.com/procps-ng/procps/raw/master/COPYING"
+  license "GPL-2.0"
+  license_file "https://gitlab.com/procps-ng/procps/raw/master/COPYING"
+  license_file "https://gitlab.com/procps-ng/procps/raw/master/COPYING.lib"
 
   # By default procps-ng will build with the 'UNKNOWN' version if not built
   # from a git repository and the '.tarball-version' file doesn't exist.

--- a/config/software/prometheus-client.rb
+++ b/config/software/prometheus-client.rb
@@ -5,7 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "Apachev2"
+  license "Apache-2.0"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/protobuf-py.rb
+++ b/config/software/protobuf-py.rb
@@ -22,7 +22,8 @@ if ohai["platform_family"] == "mac_os_x"
 end
 
 build do
-  ship_license "https://raw.githubusercontent.com/google/protobuf/3.5.x/LICENSE"
+  license "BSD-3-Clause"
+  license_file "https://raw.githubusercontent.com/google/protobuf/3.5.x/LICENSE"
 
   unless linux?
     pip "install protobuf==#{version}"

--- a/config/software/psutil.rb
+++ b/config/software/psutil.rb
@@ -5,7 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
+  license "BSD-3-CLause"
+  license_file "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/pyasn1.rb
+++ b/config/software/pyasn1.rb
@@ -5,7 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/etingof/pyasn1/master/LICENSE.rst"
+  license "BSD-2-Clause"
+  license_file "https://raw.githubusercontent.com/etingof/pyasn1/master/LICENSE.rst"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/pycurl.rb
+++ b/config/software/pycurl.rb
@@ -13,7 +13,8 @@ if ohai["platform"] != "windows"
   dependency "libgcc" if ohai["platform"] == "solaris2" && Omnibus.config.solaris_compiler == "gcc"
 
   build do
-    ship_license "https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT"
+    license "MIT"
+    license_file "https://raw.githubusercontent.com/pycurl/pycurl/master/COPYING-MIT"
     build_env = {
       "PATH" => "/#{install_dir}/embedded/bin:#{ENV["PATH"]}",
       "ARCHFLAGS" => "-arch x86_64",

--- a/config/software/pyopenssl.rb
+++ b/config/software/pyopenssl.rb
@@ -9,7 +9,8 @@ dependency "libffi"
 dependency "cryptography"
 
 build do
-  ship_license "https://raw.githubusercontent.com/pyca/pyopenssl/master/LICENSE"
+  license "Apache-2.0"
+  license_file "https://raw.githubusercontent.com/pyca/pyopenssl/master/LICENSE"
   build_env = {
     "PATH" => "#{install_dir}/embedded/bin:#{ENV["PATH"]}",
     "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",

--- a/config/software/python-consul.rb
+++ b/config/software/python-consul.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/cablehead/python-consul/master/LICENSE"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/cablehead/python-consul/master/LICENSE"
   pip "install --install-option=\"--install-scripts=#{install_dir}/bin\" python-consul==#{version}"
 end

--- a/config/software/python-etcd.rb
+++ b/config/software/python-etcd.rb
@@ -6,6 +6,7 @@ dependency "python-urllib3"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/jplana/python-etcd/master/LICENSE.txt"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/jplana/python-etcd/master/LICENSE.txt"
   pip "install --install-option=\"--install-scripts=#{install_dir}/bin\" python-etcd==#{version}"
 end

--- a/config/software/python-rrdtool.rb
+++ b/config/software/python-rrdtool.rb
@@ -3,7 +3,8 @@ default_version "1.3.8"
 dependency "python"
 
 build do
-  ship_license "https://raw.githubusercontent.com/oetiker/rrdtool-1.x/master/COPYRIGHT"
+  license "GPL-2.0 (with exception)"
+  license_file "https://raw.githubusercontent.com/oetiker/rrdtool-1.x/master/COPYRIGHT"
 
   if ohai["platform_family"] == "debian"
     command "curl -O http://dd-agent.s3.amazonaws.com/python-rrdtool/deb/#{ohai["kernel"]["machine"]}/rrdtool.so", cwd: "#{install_dir}/embedded/lib/python2.7/"

--- a/config/software/python-urllib3.rb
+++ b/config/software/python-urllib3.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/urllib3/urllib3/master/LICENSE.txt"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/urllib3/urllib3/master/LICENSE.txt"
   pip "install --install-option=\"--install-scripts=#{windows_safe_path(install_dir)}/bin\" #{name}==#{version}"
 end

--- a/config/software/python.rb
+++ b/config/software/python.rb
@@ -51,7 +51,7 @@ if ohai["platform"] != "windows"
   python_configure.push("--with-dbmliborder=")
 
   build do
-    ship_license "PSFL"
+    license "Python-2.0"
     patch source: "python-2.7.11-avoid-allocating-thunks-in-ctypes.patch" if linux?
     patch source: "python-2.7.11-fix-platform-ubuntu.diff" if linux?
 

--- a/config/software/python2.rb
+++ b/config/software/python2.rb
@@ -51,7 +51,7 @@ if ohai["platform"] != "windows"
   end
 
   build do
-    ship_license "PSFL"
+    license "Python-2.0"
     patch source: "python-2.7.11-avoid-allocating-thunks-in-ctypes.patch" if linux?
     patch source: "python-2.7.11-fix-platform-ubuntu.diff" if linux?
 

--- a/config/software/python3.rb
+++ b/config/software/python3.rb
@@ -40,7 +40,7 @@ if ohai["platform"] != "windows"
   python_configure.push("--with-dbmliborder=")
 
   build do
-    ship_license "PSFL"
+    license "Python-2.0"
 
     env = case ohai["platform"]
           when "aix"

--- a/config/software/pyyaml.rb
+++ b/config/software/pyyaml.rb
@@ -11,7 +11,8 @@ else
 end
 
 build do
-  ship_license "http://dd-agent-omnibus.s3.amazonaws.com/pyyaml-LICENSE"
+  license "MIT"
+  license_file "http://dd-agent-omnibus.s3.amazonaws.com/pyyaml-LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/rancher-metadata.rb
+++ b/config/software/rancher-metadata.rb
@@ -5,7 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/m4ce/rancher-metadata-python/master/LICENSE.txt"
+  license "Apache-2.0"
+  license_file "https://raw.githubusercontent.com/m4ce/rancher-metadata-python/master/LICENSE.txt"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/requests.rb
+++ b/config/software/requests.rb
@@ -6,7 +6,8 @@ dependency "pip"
 dependency "pyopenssl"
 
 build do
-  ship_license "https://raw.githubusercontent.com/kennethreitz/requests/master/LICENSE"
+  license "Apache-2.0"
+  license_file "https://raw.githubusercontent.com/kennethreitz/requests/master/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/setuptools-py2.rb
+++ b/config/software/setuptools-py2.rb
@@ -31,7 +31,7 @@ build do
     python_path = "#{windows_safe_path(python_2_embedded)}\\python.exe"
   end
 
-  ship_license "PSFL"
+  license "Python-2.0"
   command "#{python_path} bootstrap.py"
   command "#{python_path} setup.py install --prefix=#{windows_safe_path(python_2_embedded)}"
 end

--- a/config/software/setuptools-py3.rb
+++ b/config/software/setuptools-py3.rb
@@ -31,7 +31,7 @@ build do
     python_path = "#{windows_safe_path(python_3_embedded)}\\python.exe"
   end
 
-  ship_license "PSFL"
+  license "Python-2.0"
   command "#{python_path} bootstrap.py"
   command "#{python_path} setup.py install --prefix=#{windows_safe_path(python_3_embedded)}"
 end

--- a/config/software/setuptools.rb
+++ b/config/software/setuptools.rb
@@ -31,7 +31,7 @@ build do
     python_path = "#{windows_safe_path(install_dir)}\\embedded\\python.exe"
   end
 
-  ship_license "PSFL"
+  license "Python-2.0"
   command "#{python_path} bootstrap.py"
   command "#{python_path} setup.py install --prefix=#{windows_safe_path(install_dir)}/embedded"
 end

--- a/config/software/simplejson.rb
+++ b/config/software/simplejson.rb
@@ -5,7 +5,8 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/simplejson/simplejson/master/LICENSE.txt"
+  license "MIT"
+  license_file "https://raw.githubusercontent.com/simplejson/simplejson/master/LICENSE.txt"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/six-py2.rb
+++ b/config/software/six-py2.rb
@@ -4,6 +4,8 @@ default_version "1.11.0"
 dependency "pip-py2"
 
 build do
-  ship_license "https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/LICENSE"
+  license "MIT"
+  # Note (2021/11/12): link is dead
+  # license_file "https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/LICENSE"
   py2pip "install six==#{version}"
 end

--- a/config/software/six-py3.rb
+++ b/config/software/six-py3.rb
@@ -4,6 +4,8 @@ default_version "1.11.0"
 # dependency "pip-py2"
 
 build do
-  ship_license "https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/LICENSE"
+  license "MIT"
+  # Note (2021/11/12): link is dead
+  # license_file "https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/LICENSE"
   py3pip "install #{name}==#{version}"
 end

--- a/config/software/six.rb
+++ b/config/software/six.rb
@@ -4,6 +4,8 @@ default_version "1.12.0"
 dependency "pip"
 
 build do
-  ship_license "https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/LICENSE"
+  license "MIT"
+  # Note (2021/11/12): link is dead
+  # license_file "https://bitbucket.org/gutworth/six/raw/e5218c3f66a2614acb7572204a27e2b508682168/LICENSE"
   pip "install #{name}==#{version}"
 end

--- a/config/software/supervisor.rb
+++ b/config/software/supervisor.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
+  license "BSD-style"
+  license_file "https://raw.githubusercontent.com/Supervisor/supervisor/master/LICENSES.txt"
   pip "install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/sysstat.rb
+++ b/config/software/sysstat.rb
@@ -15,7 +15,8 @@ env = {
 }
 
 build do
-  ship_license "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
+  license "GPL-2.0"
+  license_file "https://raw.githubusercontent.com/sysstat/sysstat/master/COPYING"
   command(["./configure",
        "--prefix=#{install_dir}/embedded",
        "--disable-nls", "--disable-sensors"].join(" "),

--- a/config/software/tornado.rb
+++ b/config/software/tornado.rb
@@ -7,7 +7,8 @@ dependency "pycurl"
 dependency "futures"
 
 build do
-  ship_license "https://raw.githubusercontent.com/tornadoweb/tornado/master/LICENSE"
+  license "Apache-2.0"
+  license_file "https://raw.githubusercontent.com/tornadoweb/tornado/master/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -10,7 +10,9 @@ source url: "http://www.unixodbc.org/unixODBC-#{version}.tar.gz"
 relative_path "unixODBC-#{version}"
 
 build do
-  ship_license "./COPYING"
+  license "LGPL-2.1"
+  license_file "./COPYING"
+
   env = with_standard_compiler_flags(with_embedded_path)
 
   configure_args = [

--- a/config/software/uptime.rb
+++ b/config/software/uptime.rb
@@ -5,6 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "https://raw.githubusercontent.com/Cairnarvon/uptime/master/COPYING.txt"
+  license "BSD-2-Clause"
+  license_file "https://raw.githubusercontent.com/Cairnarvon/uptime/master/COPYING.txt"
   pip "install --install-option=\"--install-scripts=#{install_dir}/bin\" #{name}==#{version}"
 end

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -38,7 +38,9 @@ configure_env =
   end
 
 build do
-  ship_license "./COPYING"
+  license "MIT"
+  license_file "./COPYING"
+
   command "./configure --prefix=#{install_dir}/embedded", env: configure_env
   command "make -j #{workers}", env: configure_env
   command "make -j #{workers} install", env: configure_env

--- a/config/software/uuid.rb
+++ b/config/software/uuid.rb
@@ -5,7 +5,7 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "PSFL"
+  license "Python-2.0"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/wmi.rb
+++ b/config/software/wmi.rb
@@ -5,6 +5,6 @@ dependency "python"
 dependency "pip"
 
 build do
-  ship_license "MIT"
+  license "MIT"
   pip "install #{name}==#{version}"
 end

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -38,7 +38,9 @@ configure_env =
   end
 
 build do
-  ship_license "./COPYING"
+  license "MIT"
+  license_file "./COPYING"
+
   command "./configure --prefix=#{install_dir}/embedded", env: configure_env
   command "make -j #{workers}", env: configure_env
   command "make -j #{workers} install", env: configure_env

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -34,7 +34,9 @@ source url: "https://zlib.net/zlib-#{version}.tar.gz",
 relative_path "zlib-#{version}"
 
 build do
-  ship_license "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"
+  license "Zlib"
+  license_file "https://gist.githubusercontent.com/remh/77877aa00b45c1ebc152/raw/372a65de9f4c4ed376771b8d2d0943da83064726/zlib.license"
+
   if windows?
     env = with_standard_compiler_flags(with_embedded_path, bfd_flags: true)
 


### PR DESCRIPTION
Modifies the omnibus software definitions to only use the `license` and `license_file` DSL.
Adds missing license descriptions & files.