### PR TITLE
Remove usage of md5 for checksums in Agent dependencies

### DIFF
--- a/config/software/cryptography.rb
+++ b/config/software/cryptography.rb
@@ -10,6 +10,6 @@ dependency "asn1crypto"
 
 build do
   license "Apache-2.0"
-  license_file "https://github.com/pyca/cryptography/blob/master/LICENSE.APACHE"
+  license_file "https://github.com/pyca/cryptography/blob/#{version}/LICENSE.APACHE"
   pip "install cryptography==#{version}"
 end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -25,8 +25,7 @@ skip_transitive_dependency_licensing true
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency "libtool" unless windows?
 
-version("3.0.13") { source md5: "45f3b6dbc9ee7c7dfbbbc5feba571529" }
-version("3.2.1")  { source md5: "83b89587607e3eb65c70d361f13bab43" }
+version("3.2.1")  { source sha256: "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37" }
 
 source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz"
 

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -22,7 +22,7 @@ dependency "libgcc"
 dependency "config_guess"
 
 source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
-       md5: "e34509b1623cec449dfeb73d7ce9c6c6",
+       sha256: "72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613",
        extract: :seven_zip
 
 relative_path "libiconv-#{version}"

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -21,7 +21,7 @@ default_version "1.14"
 dependency "libgcc"
 dependency "config_guess"
 
-source url: "http://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
+source url: "https://ftp.gnu.org/pub/gnu/libiconv/libiconv-#{version}.tar.gz",
        sha256: "72b24ded17d687193c3366d0ebe7cde1e6b18f0df8c55438ac95be39e8a30613",
        extract: :seven_zip
 

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -19,7 +19,7 @@ name "liblzma"
 default_version "5.0.5"
 
 source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
-       md5: "19d924e066b6fff0bc9d1981b4e53196"
+       sha256: "5dcffe6a3726d23d1711a65288de2e215b4960da5092248ce63c99d50093b93a"
 
 relative_path "xz-#{version}"
 

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -18,7 +18,7 @@
 name "liblzma"
 default_version "5.0.5"
 
-source url: "http://tukaani.org/xz/xz-#{version}.tar.gz",
+source url: "https://tukaani.org/xz/xz-#{version}.tar.gz",
        sha256: "5dcffe6a3726d23d1711a65288de2e215b4960da5092248ce63c99d50093b93a"
 
 relative_path "xz-#{version}"

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -21,10 +21,7 @@ skip_transitive_dependency_licensing true
 
 dependency "config_guess"
 
-# NOTE: 2.4.6 2.4.2 do not compile on solaris2 yet
-version("2.4.6") { source md5: "addf44b646ddb4e3919805aa88fa7c5e" }
-version("2.4.2") { source md5: "d2f3b7d4627e69e13514a40e72a24d50" }
-version("2.4")   { source md5: "b32b04148ecdd7344abc6fe8bd1bb021" }
+version("2.4")   { source sha256: "13df57ab63a94e196c5d6e95d64e53262834fe780d5e82c28f177f9f71ddf62e" }
 
 source url: "https://ftp.gnu.org/gnu/libtool/libtool-#{version}.tar.gz"
 

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -30,7 +30,7 @@ env = with_standard_compiler_flags(env)
 
 build do
   license "MIT"
-  license_file "./LICENSE"
+  license_file "https://raw.githubusercontent.com/yaml/libyaml/#{version}/LICENSE"
 
   update_config_guess(target: "config")
 

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -30,7 +30,7 @@ env = with_standard_compiler_flags(env)
 
 build do
   license "MIT"
-  license_file "https://raw.githubusercontent.com/yaml/libyaml/#{version}/LICENSE"
+  license_file "./LICENSE"
 
   update_config_guess(target: "config")
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -18,7 +18,7 @@
 name "makedepend"
 default_version "1.0.5"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
+source url: "https://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
        sha256: "503903d41fb5badb73cb70d7b3740c8b30fe1cc68c504d3b6a85e6644c4e5004",
        extract: :seven_zip
 

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -19,7 +19,7 @@ name "makedepend"
 default_version "1.0.5"
 
 source url: "http://xorg.freedesktop.org/releases/individual/util/makedepend-1.0.5.tar.gz",
-       md5: "efb2d7c7e22840947863efaedc175747",
+       sha256: "503903d41fb5badb73cb70d7b3740c8b30fe1cc68c504d3b6a85e6644c4e5004",
        extract: :seven_zip
 
 relative_path "makedepend-1.0.5"

--- a/config/software/nghttp2.rb
+++ b/config/software/nghttp2.rb
@@ -5,8 +5,7 @@ dependency "openssl"
 
 source url: "https://github.com/nghttp2/nghttp2/releases/download/v#{version}/nghttp2-#{version}.tar.gz"
 
-version("1.12.0") { source md5: "04235f1d7170a2efce535068319180a1" }
-version("1.41.0") { source md5: "bd9a2745f5bbc13f8c8f0c151e1fc557" }
+version("1.41.0") { source sha256: "eacc6f0f8543583ecd659faf0a3f906ed03826f1d4157b536b4b385fe47c5bb8" }
 
 relative_path "nghttp2-#{version}"
 

--- a/config/software/pkg-config.rb
+++ b/config/software/pkg-config.rb
@@ -21,7 +21,7 @@ default_version "0.28"
 dependency "libiconv"
 
 version "0.28" do
-  source md5: "aa3c86e67551adc3ac865160e34a2a0d"
+  source sha256: "6b6eb31c6ec4421174578652c7e141fdaae2dabad1021f420d8713206ac1f845"
 end
 
 ship_source true

--- a/config/software/psutil.rb
+++ b/config/software/psutil.rb
@@ -6,7 +6,7 @@ dependency "pip"
 
 build do
   license "BSD-3-CLause"
-  license_file "https://raw.githubusercontent.com/giampaolo/psutil/master/LICENSE"
+  license_file "https://raw.githubusercontent.com/giampaolo/psutil/#{version}/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/pyyaml.rb
+++ b/config/software/pyyaml.rb
@@ -12,7 +12,7 @@ end
 
 build do
   license "MIT"
-  license_file "http://dd-agent-omnibus.s3.amazonaws.com/pyyaml-LICENSE"
+  license_file "https://raw.githubusercontent.com/yaml/pyyaml/#{version}/LICENSE"
   pip "install --install-option=\"--install-scripts="\
       "#{windows_safe_path(install_dir)}/bin\" "\
       "#{name}==#{version}"

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -2,7 +2,7 @@
 name "util-macros"
 default_version "1.19.0"
 
-source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz",
+source url: "https://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz",
        sha256: "0d4df51b29023daf2f63aebf3ebc638ea88efedfd560ab5866741ab3f92acaa1",
        extract: :seven_zip
 

--- a/config/software/util-macros.rb
+++ b/config/software/util-macros.rb
@@ -3,7 +3,7 @@ name "util-macros"
 default_version "1.19.0"
 
 source url: "http://xorg.freedesktop.org/releases/individual/util/util-macros-#{version}.tar.gz",
-       md5: "40e1caa49a71a26e0aa68ddd00203717",
+       sha256: "0d4df51b29023daf2f63aebf3ebc638ea88efedfd560ab5866741ab3f92acaa1",
        extract: :seven_zip
 
 relative_path "util-macros-#{version}"

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -3,7 +3,7 @@ name "xproto"
 default_version "7.0.27"
 
 source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz",
-       md5: "f04f535b090f3fd05073370740e99193",
+       sha256: "693d6ae50cb642fc4de6ab1f69e3f38a8e5a67eb41ac2aca253240f999282b6b",
        extract: :seven_zip
 
 relative_path "xproto-#{version}"

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -2,7 +2,7 @@
 name "xproto"
 default_version "7.0.27"
 
-source url: "http://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz",
+source url: "https://xorg.freedesktop.org/releases/individual/proto/xproto-#{version}.tar.gz",
        sha256: "693d6ae50cb642fc4de6ab1f69e3f38a8e5a67eb41ac2aca253240f999282b6b",
        extract: :seven_zip
 


### PR DESCRIPTION
Use sha256 checksums in software definitions used by the Agent.

Omnibus won't accept md5 nor sha1 anymore after we merge https://github.com/DataDog/omnibus-ruby/pull/136

Some definitions we don't use still have md5 and sha1 hashes, but that's
fine because if we ever try to use them as-is, omnibus will raise an error.