### PR TITLE
[backport] Remove usage of md5 checksums for ARM Agent dependencies

### DIFF
--- a/config/software/libedit.rb
+++ b/config/software/libedit.rb
@@ -22,11 +22,11 @@ dependency "ncurses"
 dependency "libgcc"
 
 version "20120601-3.0" do
-  source md5: "e50f6a7afb4de00c81650f7b1a0f5aea"
+  source sha256: "51f0f4b4a97b7ebab26e7b5c2564c47628cdb3042fd8ba8d0605c719d2541918"
 end
 
 version "20130712-3.1" do
-  source md5: "0891336c697362727a1fa7e60c5cb96c"
+  source sha256: "5d9b1a9dd66f1fe28bbd98e4d8ed1a22d8da0d08d902407dcc4a0702c8d88a37"
 end
 
 source url: "http://www.thrysoee.dk/editline/libedit-#{version}.tar.gz",

--- a/config/software/libxslt.rb
+++ b/config/software/libxslt.rb
@@ -24,11 +24,11 @@ dependency "liblzma"
 dependency "config_guess"
 
 version "1.1.26" do
-  source md5: "e61d0364a30146aaa3001296f853b2b9"
+  source sha256: "55dd52b42861f8a02989d701ef716d6280bfa02971e967c285016f99c66e3db1"
 end
 
 version "1.1.28" do
-  source md5: "9667bf6f9310b957254fdcf6596600b7"
+  source sha256: "5fc7151a57b89c03d7b825df5a0fae0a8d5f05674c0e7cf2937ecec4d54a028c"
 end
 
 source url: "ftp://xmlsoft.org/libxml2/libxslt-#{version}.tar.gz"

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -24,24 +24,24 @@ dependency "libedit"
 dependency "ncurses"
 
 version "9.1.9" do
-  source md5: "6b5ea53dde48fcd79acfc8c196b83535"
+  source sha256: "28a533e181009308722e8b3c51f1ea7224ab910c380ac1a86f07118667602dd8"
 end
 
 version "9.2.8" do
-  source md5: "c5c65a9b45ee53ead0b659be21ca1b97"
+  source sha256: "568ba482340219097475cce9ab744766889692ee7c9df886563e8292d66ed87c"
 end
 
 version "9.3.4" do
-  source md5: "d0a41f54c377b2d2fab4a003b0dac762"
+  source sha256: "9ee819574dfc8798a448dc23a99510d2d8924c2f8b49f8228cd77e4efc8a6621"
 end
 
 # Version lower than 9.4 aren't compatible with openssl 1.1
 # (9.4.12 for openssl 1.1.0 and 9.4.24 for visual studio)
 version "9.4.25" do
-  source md5: "5b8270dfd9a074088d3508836584260e"
+  source sha256: "cb98afaef4748de76c13202c14198e3e4717adde49fd9c90fdc81da877520928"
 end
 
-source url: "http://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
+source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 relative_path "postgresql-#{version}"
 
 configure_env = {


### PR DESCRIPTION
Backport of #413.

Follow-up of #412, this time for dependencies that are used in ARM builds of the Agent.