### PR TITLE
Use -j make option in software definitions that don't use it

### DIFF
--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -44,6 +44,6 @@ build do
   command "./configure" \
           " --prefix=/tmp/build/embedded", env: env
 
-  make env: env
-  make "install", env: env
+  command "make -j #{workers}", env: env
+  command "make install", env: env
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -167,9 +167,8 @@ build do
     end
   end
 
-  make "depend", env: env
-  # make -j N on openssl is not reliable
-  make env: env
+  command "make depend", env: env
+  command "make -j #{workers}", env: env
   if aix?
     # We have to sudo this because you can't actually run slibclean without being root.
     # Something in openssl changed in the build process so now it loads the libcrypto
@@ -180,5 +179,5 @@ build do
     # Bug Ref: http://rt.openssl.org/Ticket/Display.html?id=2986&user=guest&pass=guest
     command "sudo /usr/sbin/slibclean", env: env
   end
-  make "install", env: env
+  command "make install", env: env
 end

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -25,8 +25,8 @@ build do
   configure_command = configure_args.unshift("./configure").join(" ")
 
   command configure_command, env: env, in_msys_bash: true
-  make env: env
-  make "install", env: env
+  command "make -j #{workers}", env: env
+  command "make install", env: env
 
   # Remove the sample (empty) files unixodbc adds, otherwise they will replace
   # any user-added configuration on upgrade.


### PR DESCRIPTION
Tries to update a few software definitions that are not using multiple jobs.

For `libtool`, the `-j #{workers}` option was removed in https://github.com/DataDog/omnibus-software/pull/101, but the reason wasn't explained, and there doesn't seem to be a particular reason not to use the option.

For `unixODBC`, the `-j #{workers}` was never set: https://github.com/DataDog/omnibus-software/pull/176, but I haven't been able to find a reason why that wouldn't work.

For `openssl`, the `-j #{workers}` option was removed in https://github.com/chef/omnibus-software/pull/91 because of race condition issues during `make`, but that was on `openssl 1.0.1e`, which is 8+ years old (we currently use `1.1.1n`).

This shaves a few minutes off `datadog-agent` omnibus builds.

Test pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/pipelines/7411652