### PR TITLE
[cacerts] 2022-03-29 update

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -29,9 +29,9 @@ name "cacerts"
 # cacerts bundle changes.
 # This allows us to always use up-to-date cacerts, without breaking all builds
 # when they change.
-default_version "2022-02-01"
+default_version "2022-03-29"
 source url: "https://curl.se/ca/cacert-#{version}.pem",
-       sha256: "1d9195b76d2ea25c2b5ae9bee52d05075244d78fcd9c58ee0b6fac47d395a5eb",
+       sha256: "1979e7fe618c51ed1c9df43bba92f977a0d3fe7497ffa2a5e80dfc559a1e5a29",
        target_filename: "cacert.pem"
 
 relative_path "cacerts-#{version}"


### PR DESCRIPTION
Updates cacerts to the latest available version.

Test pipeline: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/7480656