### PR TITLE
[zlib] Bump to 1.2.12

### DIFF
--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -65,11 +65,9 @@ build do
     if solaris_10?
       # For some reason zlib needs this flag on solaris (cargocult warning?)
       env["CFLAGS"] << " -DNO_VIZ"
-    elsif freebsd?
-      # FreeBSD 10+ gets cranky if zlib is not compiled in a
-      # position-independent way.
-      env["CFLAGS"] << " -fPIC"
     end
+
+    env["CFLAGS"] << " -fPIC"
 
     configure env: env
 

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -15,20 +15,13 @@
 #
 
 name "zlib"
-default_version "1.2.11"
+default_version "1.2.12"
 
-version "1.2.11" do
-  source sha256: "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"
+version "1.2.12" do
+  source sha256: "91844808532e5ce316b3c010929493c0244f3d37593afd6de04f71821d5136d9"
 end
 
-version "1.2.8" do
-  source md5: "44d667c142d7cda120332623eab69f40"
-end
-version "1.2.6" do
-  source md5: "618e944d7c7cd6521551e30b32322f4a"
-end
-
-source url: "https://zlib.net/zlib-#{version}.tar.gz",
+source url: "https://zlib.net/fossils/zlib-#{version}.tar.gz",
        extract: :seven_zip
 
 relative_path "zlib-#{version}"


### PR DESCRIPTION
`zlib` has been updated for the first time in 5 years, [see changelog](https://zlib.net/ChangeLog.txt).

This PR updates the `zlib` version used in the datadog-agent project, as well as the download link used to download sources (`https://zlib.net/zlib-#{version}.tar.gz` only works for the latest `zlib` version).

Alternatively, we can keep using `1.2.11`, but we'll have to change the download link anyways.