### PR TITLE
Fix macOS 11 build

### DIFF
--- a/config/patches/openssl/openssl-1.1.1q-include-string.patch
+++ b/config/patches/openssl/openssl-1.1.1q-include-string.patch
@@ -1,0 +1,13 @@
+Fix https://github.com/openssl/openssl/issues/18720
+diff --git openssl-1.1.1q/test/v3ext.c openssl-1.1.1q/test/v3ext.c
+index 386135f..7a240cd 100644
+--- openssl-1.1.1q/test/v3ext.c
++++ openssl-1.1.1q/test/v3ext.c
+@@ -8,6 +8,7 @@
+  */
+
+ #include <stdio.h>
++#include <string.h>
+ #include <openssl/x509.h>
+ #include <openssl/x509v3.h>
+ #include <openssl/pem.h>

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -168,6 +168,10 @@ build do
     else
       patch source: "openssl-1.1.1d-do-not-build-docs.patch", env: env
     end
+
+    if mac_os_x?
+      patch source: "openssl-1.1.1q-include-string.patch", env: env
+    end
   end
 
   command "make depend", env: env

--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -1,9 +1,8 @@
 name "unixodbc"
-default_version "2.3.7"
+default_version "2.3.9"
 
-version "2.3.7" do
-  source sha256: "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77"
-end
+version("2.3.7") { source sha256: "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77"}
+version("2.3.9") { source sha256: "52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207"}
 
 source url: "http://www.unixodbc.org/unixODBC-#{version}.tar.gz"
 


### PR DESCRIPTION
Makes the Datadog Agent buildable on the macOS 11 Github Actions runners. In particular:

- Applies patch to OpenSSL to address openssl/openssl/issues/18720
- Bumps unixODBC version to address https://trac.macports.org/ticket/61460