### PR TITLE
[agent-v5] updates to fix current build

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -21,7 +21,7 @@ name "cacerts"
 default_version "latest"
 
 source url: "https://curl.haxx.se/ca/cacert.pem",
-       sha256: "2cff03f9efdaf52626bd1b451d700605dc1ea000c5da56bd0fc59f8f43071040"
+       sha256: "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0"
 
 relative_path "cacerts-#{version}"
 

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -1,5 +1,5 @@
 name "datadog-gohai"
-default_version "last-stable"
+default_version "agent-v5"
 
 always_build true
 

--- a/config/software/datadog-gohai.rb
+++ b/config/software/datadog-gohai.rb
@@ -19,18 +19,20 @@ end
 build do
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/LICENSE"
   ship_license "https://raw.githubusercontent.com/DataDog/gohai/#{version}/THIRD_PARTY_LICENSES.md"
-  # Checkout gohai's deps
-  command "#{gobin} get -d github.com/shirou/gopsutil", :env => env
-  command "git checkout v2.0.0", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/shirou/gopsutil"
-  command "#{gobin} get -d github.com/cihub/seelog", :env => env
-  command "git checkout v2.6", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/cihub/seelog"
+
+  # Checkout gohai
+  command "#{gobin} get -d github.com/DataDog/gohai", :env => env # No need to pull latest from remote with `-u` here since the next command checks out and pulls latest
+  command "git checkout #{version} && git pull", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/#{name}/src/github.com/DataDog/gohai"
+
+  # Checkout correct version for gohai's deps
+  command "git checkout v2.0.0", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/#{name}/src/github.com/shirou/gopsutil"
+  command "git checkout v2.6", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/#{name}/src/github.com/cihub/seelog"
   # Windows depends on the registry, go get that.
   if ohai["platform"] == "windows"
     command "#{gobin} get -d golang.org/x/sys/windows/registry", :env => env
-    command "git checkout 5f54ce54270977bfbd7353a37e64c13d6bd6c9c9", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/golang.org/x/sys/windows/registry"
+    command "git checkout 5f54ce54270977bfbd7353a37e64c13d6bd6c9c9", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/#{name}/src/golang.org/x/sys/windows/registry"
   end
-  # Checkout and build gohai
-  command "#{gobin} get -d github.com/DataDog/gohai", :env => env # No need to pull latest from remote with `-u` here since the next command checks out and pulls latest
-  command "git checkout #{version} && git pull", :env => env, :cwd => "#{Omnibus::Config.cache_dir}/src/datadog-gohai/src/github.com/DataDog/gohai"
+
+  # Build gohai
   command "cd #{env['GOPATH']}/src/github.com/DataDog/gohai && #{gobin} run make.go #{gobin} && mv gohai #{install_dir}/bin/gohai", :env => env
 end

--- a/config/software/nfsiostat.rb
+++ b/config/software/nfsiostat.rb
@@ -16,7 +16,7 @@
 #
 
 name "nfsiostat"
-default_version "nfs-utils-2-1-1"
+default_version "vsock"
 
 source :git => "https://github.com/stefanha/nfs-utils.git"
 

--- a/config/software/nfsiostat.rb
+++ b/config/software/nfsiostat.rb
@@ -18,7 +18,7 @@
 name "nfsiostat"
 default_version "nfs-utils-2-1-1"
 
-source :git => "git://git.linux-nfs.org/projects/steved/nfs-utils.git"
+source :git => "https://github.com/stefanha/nfs-utils.git"
 
 relative_path "nfs-utils"
 

--- a/config/software/nfsiostat.rb
+++ b/config/software/nfsiostat.rb
@@ -24,7 +24,7 @@ end
 
 source :url => "https://cdn.kernel.org/pub/linux/utils/nfs-utils/#{version}/nfs-utils-#{version}.tar.gz"
 
-relative_path "nfs-utils"
+relative_path "nfs-utils-#{version}"
 
 build do
   mkdir "#{install_dir}/embedded/sbin/"

--- a/config/software/nfsiostat.rb
+++ b/config/software/nfsiostat.rb
@@ -16,9 +16,13 @@
 #
 
 name "nfsiostat"
-default_version "vsock"
+default_version "2.1.1"
 
-source :git => "https://github.com/stefanha/nfs-utils.git"
+version "2.1.1" do
+  source :sha256 => "381bb3f6aa4b314538db0bcfb242da855c2eb36e2059cf61aa498c0220684363"
+end
+
+source :url => "https://cdn.kernel.org/pub/linux/utils/nfs-utils/#{version}/nfs-utils-#{version}.tar.gz"
 
 relative_path "nfs-utils"
 

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -15,7 +15,11 @@
 #
 
 name "zlib"
-default_version "1.2.11"
+default_version "1.2.13"
+
+version "1.2.13" do
+  source sha256: "b3a24de97a8fdbc835b9833169501030b8977031bcb54b3b3ac13740f846ab30"
+end
 
 version "1.2.11" do
   source sha256: "c3e5e9fdd5004dcb542feda5ee4f0ff0744628baf8ed2dd5d66f8ca1197cb1a1"


### PR DESCRIPTION
- zlib: bump to 1.2.13; previous versions unavailable (+ vulnerable)
- nfsiostat: new git repository
- gohai: change order in which deps are collected, checked out. 