### PR TITLE
Backport cacerts 2023-01-10 update

### DIFF
--- a/config/software/cacerts.rb
+++ b/config/software/cacerts.rb
@@ -29,9 +29,9 @@ name "cacerts"
 # cacerts bundle changes.
 # This allows us to always use up-to-date cacerts, without breaking all builds
 # when they change.
-default_version "2022-10-11"
+default_version "2023-01-10"
 source url: "https://curl.se/ca/cacert-#{version}.pem",
-       sha256: "2cff03f9efdaf52626bd1b451d700605dc1ea000c5da56bd0fc59f8f43071040",
+       sha256: "fb1ecd641d0a02c01bc9036d513cb658bbda62a75e246bedbc01764560a639f0",
        target_filename: "cacert.pem"
 
 relative_path "cacerts-#{version}"


### PR DESCRIPTION
This is backport of #435 in `7.42.x` for possible `7.42.1` releases !