### PR TITLE
Bump gdbm version to 1.23

### DIFF
--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -45,6 +45,7 @@ build do
   configure_command = ["./configure",
                        "--enable-libgdbm-compat",
                        "--without-readline",
+                       "--disable-static",
                        "--prefix=#{install_dir}/embedded"]
 
   if ohai["platform"] == "freebsd"

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -16,12 +16,12 @@
 #
 
 name "gdbm"
-default_version "1.11"
+default_version "1.23"
 
 dependency "libgcc"
 
 source url: "http://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz",
-       md5: "72c832680cf0999caedbe5b265c8c1bd"
+       sha256: "74b1081d21fff13ae4bd7c16e5d6e504a4c26f7cde1dca0d963a484174bbcacd"
 
 relative_path "gdbm-#{version}"
 
@@ -44,6 +44,7 @@ build do
 
   configure_command = ["./configure",
                        "--enable-libgdbm-compat",
+                       "--without-readline",
                        "--prefix=#{install_dir}/embedded"]
 
   if ohai["platform"] == "freebsd"
@@ -53,4 +54,6 @@ build do
   command configure_command.join(" "), env: env
   command "make -j #{workers}", env: env
   command "make install", env: env
+
+  command "rm #{install_dir}/embedded/bin/gdbmtool"
 end

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -55,5 +55,8 @@ build do
   command "make -j #{workers}", env: env
   command "make install", env: env
 
+  # drop some cli tools we do not use
   command "rm #{install_dir}/embedded/bin/gdbmtool"
+  command "rm #{install_dir}/embedded/bin/gdbm_dump"
+  command "rm #{install_dir}/embedded/bin/gdbm_load"
 end

--- a/config/software/gdbm.rb
+++ b/config/software/gdbm.rb
@@ -26,6 +26,9 @@ source url: "http://ftp.gnu.org/gnu/gdbm/gdbm-#{version}.tar.gz",
 relative_path "gdbm-#{version}"
 
 build do
+  license "GPL-3.0"
+  license_file "COPYING"
+
   env = case ohai["platform"]
         when "solaris2"
           {


### PR DESCRIPTION
Used by `cyrus-sasl.rb` in this PR: https://github.com/DataDog/datadog-agent/pull/15470. 

Bumping this version as it is currently pretty old

Note: 

- We tested the docker image generated in the related PR, everything's OK so far.
- Looks like we are the only one to use this formula