### PR TITLE
ducolombier/expat

### DIFF
--- a/config/patches/expat/configure_xlc_visibility.patch
+++ b/config/patches/expat/configure_xlc_visibility.patch
@@ -1,0 +1,58 @@
+--- expat-2.4.1/configure.orig	2021-05-23 11:28:43.000000000 -0500
++++ expat-2.4.1/configure	2021-08-03 09:21:25.000000000 -0500
+@@ -12602,7 +12602,7 @@
+ #  endif
+ #endif
+ 
+-/* When -fvisibility=hidden is used, assume the code has been annotated
++/* When -qvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+ #if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+@@ -12708,7 +12708,7 @@
+ #  endif
+ #endif
+ 
+-/* When -fvisibility=hidden is used, assume the code has been annotated
++/* When -qvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+ #if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+@@ -17541,7 +17541,7 @@
+ else
+   expatcfg_cv_compiler_supports_visibility=no
+       OLDFLAGS=$CFLAGS
+-      as_fn_append CFLAGS " -fvisibility=hidden -Wall -Werror -Wno-unknown-warning-option"
++      as_fn_append CFLAGS " -qvisibility=hidden -Wall -Werror -Wno-unknown-warning-option"
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -17563,15 +17563,15 @@
+ if ${AM_CFLAGS+:} false; then :
+ 
+   case " $AM_CFLAGS " in #(
+-  *" -fvisibility=hidden "*) :
+-    { { $as_echo "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS already contains -fvisibility=hidden"; } >&5
+-  (: AM_CFLAGS already contains -fvisibility=hidden) 2>&5
++  *" -qvisibility=hidden "*) :
++    { { $as_echo "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS already contains -qvisibility=hidden"; } >&5
++  (: AM_CFLAGS already contains -qvisibility=hidden) 2>&5
+   ac_status=$?
+   $as_echo "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } ;; #(
+   *) :
+ 
+-     as_fn_append AM_CFLAGS " -fvisibility=hidden"
++     as_fn_append AM_CFLAGS " -qvisibility=hidden"
+      { { $as_echo "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS=\"\$AM_CFLAGS\""; } >&5
+   (: AM_CFLAGS="$AM_CFLAGS") 2>&5
+   ac_status=$?
+@@ -17582,7 +17582,7 @@
+ 
+ else
+ 
+-  AM_CFLAGS=-fvisibility=hidden
++  AM_CFLAGS=-qvisibility=hidden
+   { { $as_echo "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS=\"\$AM_CFLAGS\""; } >&5
+   (: AM_CFLAGS="$AM_CFLAGS") 2>&5
+   ac_status=$?

--- a/config/patches/expat/configure_xlc_visibility_2.4.7.patch
+++ b/config/patches/expat/configure_xlc_visibility_2.4.7.patch
@@ -1,0 +1,59 @@
+--- expat-2.4.1/configure.orig	2021-05-23 11:28:43.000000000 -0500
++++ expat-2.4.1/configure	2021-08-03 09:21:25.000000000 -0500
+@@ -13387,7 +13387,7 @@
+ #  endif
+ #endif
+ 
+-/* When -fvisibility=hidden is used, assume the code has been annotated
++/* When -qvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+ #if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+@@ -13494,7 +13494,7 @@
+ #  endif
+ #endif
+ 
+-/* When -fvisibility=hidden is used, assume the code has been annotated
++/* When -qvisibility=hidden is used, assume the code has been annotated
+    correspondingly for the symbols needed.  */
+ #if defined __GNUC__ && (((__GNUC__ == 3) && (__GNUC_MINOR__ >= 3)) || (__GNUC__ > 3))
+ int fnord () __attribute__((visibility("default")));
+@@ -18325,7 +18325,7 @@
+ else $as_nop
+   expatcfg_cv_compiler_supports_visibility=no
+       OLDFLAGS=$CFLAGS
+-      as_fn_append CFLAGS " -fvisibility=hidden -Wall -Werror -Wno-unknown-warning-option"
++      as_fn_append CFLAGS " -qvisibility=hidden -Wall -Werror -Wno-unknown-warning-option"
+       cat confdefs.h - <<_ACEOF >conftest.$ac_ext
+ /* end confdefs.h.  */
+ 
+@@ -18349,16 +18349,16 @@
+ if test ${AM_CFLAGS+y}
+ then :
+ 
+   case " $AM_CFLAGS " in #(
+-  *" -fvisibility=hidden "*) :
+-    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS already contains -fvisibility=hidden"; } >&5
+-  (: AM_CFLAGS already contains -fvisibility=hidden) 2>&5
++  *" -qvisibility=hidden "*) :
++    { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS already contains -qvisibility=hidden"; } >&5
++  (: AM_CFLAGS already contains -qvisibility=hidden) 2>&5
+   ac_status=$?
+   printf "%s\n" "$as_me:${as_lineno-$LINENO}: \$? = $ac_status" >&5
+   test $ac_status = 0; } ;; #(
+   *) :
+ 
+-     as_fn_append AM_CFLAGS " -fvisibility=hidden"
++     as_fn_append AM_CFLAGS " -qvisibility=hidden"
+      { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS=\"\$AM_CFLAGS\""; } >&5
+   (: AM_CFLAGS="$AM_CFLAGS") 2>&5
+   ac_status=$?
+@@ -18369,7 +18369,7 @@
+ 
+ else $as_nop
+ 
+-  AM_CFLAGS=-fvisibility=hidden
++  AM_CFLAGS=-qvisibility=hidden
+   { { printf "%s\n" "$as_me:${as_lineno-$LINENO}: : AM_CFLAGS=\"\$AM_CFLAGS\""; } >&5
+   (: AM_CFLAGS="$AM_CFLAGS") 2>&5
+   ac_status=$?

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -28,13 +28,6 @@ skip_transitive_dependency_licensing true
 source url: "https://github.com/libexpat/libexpat/releases/download/R_#{version.gsub(".", "_")}/expat-#{version}.tar.gz"
 
 version("2.5.0") { source sha256: "6b902ab103843592be5e99504f846ec109c1abb692e85347587f237a4ffa1033" }
-version("2.4.9") { source sha256: "4415710268555b32c4e5ab06a583bea9fec8ff89333b218b70b43d4ca10e38fa" }
-version("2.4.8") { source sha256: "398f6d95bf808d3108e27547b372cb4ac8dc2298a3c4251eb7aa3d4c6d4bb3e2" }
-version("2.4.7") { source sha256: "72644d5f0f313e2a5cf81275b09b9770c866dd87a2b62ab19981657ac0d4af5f" }
-version("2.4.6") { source sha256: "a0eb5af56b1c2ba812051c49bf3b4e5763293fe5394a0219df7208845c3efb8c" }
-version("2.4.1") { source sha256: "a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b" }
-version("2.3.0") { source sha256: "89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987" }
-version("2.1.0") { source sha256: "823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86" }
 
 build do
   env = with_standard_compiler_flags(with_embedded_path)

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -1,21 +1,64 @@
+#
+# Copyright 2014 Chef Software, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
 name "expat"
-default_version "2.1.1"
+default_version "2.5.0"
 
-relative_path "expat-2.1.1"
+relative_path "expat-#{version}"
+dependency "config_guess"
 
-source url: "http://downloads.sourceforge.net/project/expat/expat/2.1.1/expat-2.1.1.tar.bz2?r=https%3A%2F%2Fsourceforge.net%2Fprojects%2Fexpat%2F&ts=1465411104&use_mirror=heanet",
-       md5: "7380a64a8e3a9d66a9887b01d0d7ea81"
+license "MIT"
+license_file "COPYING"
+skip_transitive_dependency_licensing true
 
-env = {
-  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-}
+# version_list: url=https://github.com/libexpat/libexpat/releases filter=*.tar.gz
+source url: "https://github.com/libexpat/libexpat/releases/download/R_#{version.gsub(".", "_")}/expat-#{version}.tar.gz"
+
+version("2.5.0") { source sha256: "6b902ab103843592be5e99504f846ec109c1abb692e85347587f237a4ffa1033" }
+version("2.4.9") { source sha256: "4415710268555b32c4e5ab06a583bea9fec8ff89333b218b70b43d4ca10e38fa" }
+version("2.4.8") { source sha256: "398f6d95bf808d3108e27547b372cb4ac8dc2298a3c4251eb7aa3d4c6d4bb3e2" }
+version("2.4.7") { source sha256: "72644d5f0f313e2a5cf81275b09b9770c866dd87a2b62ab19981657ac0d4af5f" }
+version("2.4.6") { source sha256: "a0eb5af56b1c2ba812051c49bf3b4e5763293fe5394a0219df7208845c3efb8c" }
+version("2.4.1") { source sha256: "a00ae8a6b96b63a3910ddc1100b1a7ef50dc26dceb65ced18ded31ab392f132b" }
+version("2.3.0") { source sha256: "89df123c62f2c2e2b235692d9fe76def6a9ab03dbe95835345bf412726eb1987" }
+version("2.1.0") { source sha256: "823705472f816df21c8f6aa026dd162b280806838bb55b3432b0fb1fcca7eb86" }
 
 build do
-  command ["./configure",
-           "--prefix=#{install_dir}/embedded"].join(" "), env: env
+  env = with_standard_compiler_flags(with_embedded_path)
 
-  command "make -j #{workers}", env: env
-  command "make install"
+  update_config_guess(target: "conftools")
+
+  # AIX needs two fixes to compile the latest version.
+  #  1. We need to add -lm to link in the proper math declarations
+  #  2. Since we are using xlc to compile, we need to use qvisibility instead of fvisibility
+  #     Refer to https://www.ibm.com/docs/en/xl-c-and-cpp-aix/16.1?topic=descriptions-qvisibility-fvisibility
+  if aix?
+    env["LDFLAGS"] << " -lm"
+    if version <= "2.4.1"
+      patch source: "configure_xlc_visibility.patch", plevel: 1, env: env
+    else
+      patch source: "configure_xlc_visibility_2.4.7.patch", plevel: 1, env: env
+    end
+  end
+
+  command "./configure" \
+          " --without-examples" \
+          " --without-tests" \
+          " --prefix=#{install_dir}/embedded", env: env
+
+  make "-j #{workers}", env: env
+  make "install", env: env
 end

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -48,6 +48,7 @@ build do
   end
 
   command "./configure" \
+          " --disable-static" \
           " --without-examples" \
           " --without-tests" \
           " --prefix=#{install_dir}/embedded", env: env


### PR DESCRIPTION
This change replaces the `expat` package with the upstream version from the [omnibus-software](https://github.com/chef/omnibus-software) repository.

Expat is an XML parser library and is required to build `dbus`, which is a dependency to enable the `systemd` probe in OpenSCAP.