### PR TITLE
 Change git source to url to ensure it is cached

### DIFF
--- a/config/software/nfsiostat.rb
+++ b/config/software/nfsiostat.rb
@@ -18,7 +18,9 @@
 name "nfsiostat"
 default_version "nfs-utils-2-1-1"
 
-source git: "git://git.linux-nfs.org/projects/steved/nfs-utils.git"
+source url: "https://mirrors.edge.kernel.org/pub/linux/utils/nfs-utils/2.1.1/nfs-utils-2.1.1.tar.gz"
+       sha256: "381bb3f6aa4b314538db0bcfb242da855c2eb36e2059cf61aa498c0220684363"
+       extract: :seven_zip
 
 relative_path "nfs-utils"
 


### PR DESCRIPTION

## Description
Change the source of nfsiostat from git to url.
Git sources are not cached and it creates problems when the git source are no longer available
## Related Issue

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
