### PR TITLE
AP-2164 Update config_guess source from git to url, to be sure it is cached b…

### DIFF
--- a/config/software/config_guess.rb
+++ b/config/software/config_guess.rb
@@ -18,7 +18,8 @@ name "config_guess"
 default_version "master"
 
 # Use our github mirror of the savannah repository
-source git: "https://github.com/chef/config-mirror.git"
+source url: "https://github.com/chef-boneyard/config-mirror/archive/refs/heads/#{version}.tar.gz",
+       sha256: "cc60204d0b512cfd86eca96c079b48494495c5b7937c873b708cce81ca52dc2d"
 
 # http://savannah.gnu.org/projects/config
 license "GPL-3.0 (with exception)"
@@ -26,7 +27,7 @@ license_file "config.guess"
 license_file "config.sub"
 skip_transitive_dependency_licensing true
 
-relative_path "config_guess-#{version}"
+relative_path "config-mirror-#{version}"
 
 build do
   mkdir "/tmp/build/embedded/lib/config_guess"


### PR DESCRIPTION
## Description
Use a URL source instead of Git source, because Git sources are not cached by omnibus and will break if the source become unavailable.
We want to update all the software using git source that are used by the agent build. All the other software with git source are not used.
## Related Issue
## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have run the pre-merge tests locally and they pass.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
- [ ] All commits have been signed-off for [the Developer Certificate of Origin](https://github.com/chef/chef/blob/master/CONTRIBUTING.md#developer-certification-of-origin-dco).
