### PR TITLE
Remove static libraries from install directory

### DIFF
--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -52,4 +52,5 @@ build do
   make "#{args}", env: env
   make "#{args} -f Makefile-libbz2_so", env: env
   make "#{args} install", env: env
+  delete "#{install_dir}/embedded/lib/libbz2.a"
 end

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -36,7 +36,7 @@ build do
 
   env["INSTALL"] = "/opt/freeware/bin/install" if aix?
 
-  configure_command = []
+  configure_command = ["--disable-static", "--disable-docs"]
 
   # AIX's old version of patch doesn't like the patch here
   unless aix?

--- a/config/software/liblzma.rb
+++ b/config/software/liblzma.rb
@@ -47,6 +47,7 @@ build do
     "--disable-lzmadec",
     "--disable-xzdec",
     "--disable-xz",
+    "--disable-static",
   ]
   config_command << "--disable-nls" if windows?
 

--- a/config/software/libtool.rb
+++ b/config/software/libtool.rb
@@ -46,6 +46,7 @@ build do
   end
 
   command "./configure" \
+          " --disable-static" \
           " --prefix=#{install_dir}/embedded", env: env
 
   make env: env

--- a/config/software/nghttp2.rb
+++ b/config/software/nghttp2.rb
@@ -19,6 +19,8 @@ build do
 
   command [
     "./configure",
+    "--disable-static",
+    "--enable-shared",
     "--disable-app",
     "--disable-examples",
     "--disable-hpack-tools",

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -185,4 +185,10 @@ build do
     command "sudo /usr/sbin/slibclean", env: env
   end
   command "make install", env: env
+
+  unless windows?
+    # Remove openssl static libraries here as we can't disable those at build time
+    delete "#{install_dir}/embedded/lib/libcrypto.a"
+    delete "#{install_dir}/embedded/lib/libssl.a"
+  end
 end

--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -90,4 +90,10 @@ build do
   command "make depend", env: env
   command "make -j #{workers}", env: env
   command "make install", env: env
+
+  unless windows?
+    # Remove openssl static libraries here as we can't disable those at build time
+    delete "#{install_dir}/embedded/lib/libcrypto.a"
+    delete "#{install_dir}/embedded/lib/libssl.a"
+  end
 end

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -61,4 +61,13 @@ build do
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
   delete "#{install_dir}/embedded/lib/postgresql/pgxs/src/test/"
+  delete "#{install_dir}/embedded/lib/libecpg.a"
+  delete "#{install_dir}/embedded/lib/libecpg_compat.a"
+  delete "#{install_dir}/embedded/lib/libltdl.a"
+  delete "#{install_dir}/embedded/lib/liblua.a"
+  delete "#{install_dir}/embedded/lib/libpgcommon.a"
+  delete "#{install_dir}/embedded/lib/libpgfeutils.a"
+  delete "#{install_dir}/embedded/lib/libpgport.a"
+  delete "#{install_dir}/embedded/lib/libpgtypes.a"
+  delete "#{install_dir}/embedded/lib/libpq.a"
 end

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -31,8 +31,11 @@ build do
   command(["./configure",
            "--prefix=#{install_dir}/embedded",
            "--without-ncurses",
+           "--disable-nls",
            ""].join(" "),
     env: env)
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
+
+  delete "#{install_dir}/embedded/lib/libprocps.a"
 end

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -73,5 +73,8 @@ build do
 
     make "-j #{workers}", env: env
     make "-j #{workers} install", env: env
+
+    delete "#{install_dir}/embedded/lib/libz.a"
+    delete "#{install_dir}/embedded/share/man/man3/zlib.3"
   end
 end


### PR DESCRIPTION
This PR disables static libraries generation, or removes those files when the build system doesn't allow for disabling.
It also removes i18n support from a few softwares.

The intent is to reduce the size of our artifacts, and since we don't need the shared libraries to be shipped, might as well remove them. Static libraries account for ≃25MB in the debian package (I haven't checked the footprint for other platforms/distributions)