### PR TITLE
openssl: bump default version to 3.0.11

### DIFF
--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -24,13 +24,14 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless windows?
 
-default_version "3.0.9"
+default_version "3.0.11"
 
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
 version("3.1.0") { source sha256: "aaa925ad9828745c4cad9d9efeb273deca820f2cdcf2c3ac7d7c1212b7c497b4" }
 version("3.0.9") { source sha256: "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65a603cabbf1b00a1dc90" }
 version("3.0.8") { source sha256: "6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e" }
+version("3.0.11") { source sha256: "b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55" }
 
 relative_path "openssl-#{version}"
 


### PR DESCRIPTION
(cherry picked from commit ae78827ec7731a1142b9be4c89cf529b758e81f2)
Signed-off-by: Hugo Beauzée-Luyssen <hugo.beauzee@datadoghq.com>