### PR TITLE
Bump postgresql dep to latest version

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -16,7 +16,7 @@
 #
 
 name "postgresql"
-default_version "10.19" # 10.19 is the oldest version with OpenSSL 3 support
+default_version "16.0"
 
 dependency "zlib"
 dependency ENV["OMNIBUS_OPENSSL_SOFTWARE"] || "openssl"

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -21,6 +21,10 @@ default_version "16.0"
 dependency "zlib"
 dependency ENV["OMNIBUS_OPENSSL_SOFTWARE"] || "openssl"
 
+version "16.0" do
+  source sha256: "df9e823eb22330444e1d48e52cc65135a652a6fdb3ce325e3f08549339f51b99"
+end
+
 version "10.19" do
   source sha256: "6eb830b428b60e84ae87e20436bce679c4d9d0202be7aec0e41b0c67d9134239"
 end


### PR DESCRIPTION
Bumps postgres dep to the [latest verison](https://www.postgresql.org/docs/release/16.0/), which we can support now that we have merged a change to deploy [the latest version](https://github.com/DataDog/integrations-core/pull/15949) of `psycopg2`, which ships with the latest version of `libpq` & that supports postgres 16. 

This fixes some [reported CVEs](https://www.cvedetails.com/vulnerability-list/vendor_id-336/product_id-575/version_id-1354580/Postgresql-Postgresql-10.19.html) for postgresql 10 (its a very old version)