### PR TITLE
Revert "Bump postgresql dep to latest version"

### DIFF
--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -16,14 +16,10 @@
 #
 
 name "postgresql"
-default_version "16.0"
+default_version "10.19" # 10.19 is the oldest version with OpenSSL 3 support
 
 dependency "zlib"
 dependency ENV["OMNIBUS_OPENSSL_SOFTWARE"] || "openssl"
-
-version "16.0" do
-  source sha256: "df9e823eb22330444e1d48e52cc65135a652a6fdb3ce325e3f08549339f51b99"
-end
 
 version "10.19" do
   source sha256: "6eb830b428b60e84ae87e20436bce679c4d9d0202be7aec0e41b0c67d9134239"


### PR DESCRIPTION
Reverts DataDog/omnibus-software#484

seems that macOS builds are failing while building postgres: https://github.com/DataDog/datadog-agent-macos-build/actions/runs/6627986944/job/18004107867