### PR TITLE
curl: don't provide path to dependencies

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -33,8 +33,7 @@ build do
     FileUtils.rm_rf(File.join(project_dir, "src/tool_hugehelp.c"))
   end
 
-  # curl requires pkg-config that is shipped with the agent
-  env = { "PATH" => "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"] }
+  env = with_standard_compiler_flags(with_embedded_path)
   configure_options = [
            "--disable-manual",
            "--disable-debug",


### PR DESCRIPTION
Test build at: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/pipelines/22337037

Let pkg-config do its job instead. This fix a potential issue (most likely only
in more recent toolchains than the one we use in the build images) where curl
would explicitly depend on the absolute path to its dependencies, causing it to
link with /path/to/libfoo.so instead of -lfoo
When linking with an absolute path, the linker appears to not include the rpath
information, which causes linking errors down the line:
```
2023-10-25T15:16:09+00:00 | /opt/toolchains/bin/../lib/gcc/x86_64-unknown-linux-gnu/11.4.0/../../../../x86_64-unknown-linux-gnu/bin/ld.bfd: warning: libnghttp2.so.14, needed by ../lib/.libs/libcurl.so, not found (try using -rpath or -rpath-link)
```