### PR TITLE
update sqlite to 3.43.1

### DIFF
--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -18,11 +18,11 @@ build do
   license "Public-Domain"
 
   update_config_guess
-  command(["./configure",
-       "--prefix=#{install_dir}/embedded",
-       "--disable-nls",
-       "--disable-static"].join(" "),
-    env: env)
+  configure_options = [
+    "--disable-nls",
+    "--disable-static",
+  ]
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
   delete "#{install_dir}/embedded/bin/sqlite3"

--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -1,12 +1,12 @@
 name "libsqlite3"
-default_version "3.35.5"
+default_version "3.43.1"
 
 dependency "config_guess"
 
-source url: "https://www.sqlite.org/2021/sqlite-autoconf-3350500.tar.gz",
-       sha256: "f52b72a5c319c3e516ed7a92e123139a6e87af08a2dc43d7757724f6132e6db0"
+source url: "https://www.sqlite.org/2023/sqlite-autoconf-3430101.tar.gz",
+       sha256: "098984eb36a684c90bc01c0eb7bda3273c327cbc3673d7d0bc195028c19fb7b0"
 
-relative_path "sqlite-autoconf-3350500"
+relative_path "sqlite-autoconf-3430100"
 
 env = {
   "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",

--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -21,6 +21,10 @@ build do
   configure_options = [
     "--disable-nls",
     "--disable-static",
+    "--enable-shared",
+    "--enable-pic",
+    "--disable-editline",
+    "--disable-readling",
   ]
   configure(*configure_options, env: env)
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }


### PR DESCRIPTION
This PR is updating sqlite3 to the version we were already building in the datadog-agent repo (3.43.1) and updated a few things in the recipe.