### PR TITLE
CI: don't trigger a datadog-agent pipeline on tags

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -12,6 +12,8 @@ stages:
       when: never
     - if: $CI_COMMIT_BRANCH =~ /^7.[0-9]{2}.x/
       when: never
+    - if: $CI_COMMIT_TAG != null
+      when: never
     - when: always
 
 trigger-agent-build:


### PR DESCRIPTION
We are currently excluding stable branches, but not the tags associated with them, which causes a pipeline to be created while we already tested the build with the commits it contains