### PR TITLE
[VULNOPS-1127] Upgrade nghttp2

### DIFF
--- a/config/software/nghttp2.rb
+++ b/config/software/nghttp2.rb
@@ -1,5 +1,5 @@
 name "nghttp2"
-default_version "1.41.0"
+default_version "1.58.0"
 
 # NOTE: Historically nghttp2 had openssl dependency here. It turns out it's
 # not actually needed. It is only required to build the "app" (which we
@@ -10,6 +10,7 @@ default_version "1.41.0"
 source url: "https://github.com/nghttp2/nghttp2/releases/download/v#{version}/nghttp2-#{version}.tar.gz"
 
 version("1.41.0") { source sha256: "eacc6f0f8543583ecd659faf0a3f906ed03826f1d4157b536b4b385fe47c5bb8" }
+version("1.58.0") { source sha256: "9ebdfbfbca164ef72bdf5fd2a94a4e6dfb54ec39d2ef249aeb750a91ae361dfb" }
 
 relative_path "nghttp2-#{version}"
 


### PR DESCRIPTION
Upgrade `nghttp2` to `1.58.0` to get the fix for [CVE-2023-35945](https://nvd.nist.gov/vuln/detail/CVE-2023-35945).