### PR TITLE
Use our existing wrappers for cmake & configure

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -33,8 +33,7 @@ build do
     FileUtils.rm_rf(File.join(project_dir, "src/tool_hugehelp.c"))
   end
 
-  command ["./configure",
-           "--prefix=#{install_dir}/embedded",
+  configure_options = [
            "--disable-manual",
            "--disable-debug",
            "--enable-optimize",
@@ -51,7 +50,9 @@ build do
            "--without-libssh2",
            "--with-ssl=#{install_dir}/embedded",
            "--with-zlib=#{install_dir}/embedded",
-           "--with-nghttp2=#{install_dir}/embedded"].join(" ")
+           "--with-nghttp2=#{install_dir}/embedded",
+  ]
+  configure(*configure_options)
 
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"

--- a/config/software/expat.rb
+++ b/config/software/expat.rb
@@ -47,11 +47,12 @@ build do
     end
   end
 
-  command "./configure" \
-          " --disable-static" \
-          " --without-examples" \
-          " --without-tests" \
-          " --prefix=#{install_dir}/embedded", env: env
+  configure_options = [
+    "--disable-static",
+    " --without-examples",
+    " --without-tests",
+  ]
+  configure(*configure_options, env: env)
 
   make "-j #{workers}", env: env
   make "install", env: env

--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -26,25 +26,23 @@ source url: "https://www.libarchive.org/downloads/libarchive-#{version}.tar.gz",
 
 relative_path "libarchive-#{version}"
 
-env = {
-  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include ",
-}
-
 build do
-  command "./configure --prefix=#{install_dir}/embedded \
-    --without-lzma \
-    --without-lzo2 \
-    --without-nettle \
-    --without-xml2 \
-    --without-expat \
-    --without-bz2lib \
-    --without-iconv \
-    --without-zlib \
-    --disable-bsdtar \
-    --disable-bsdcpio \
-    --without-lzmadec \
-    --without-openssl", env: env
+  env = with_standard_compiler_flags(with_embedded_path)
+  configure_options = [
+    "--without-lzma",
+    "--without-lzo2",
+    "--without-nettle",
+    "--without-xml2",
+    "--without-expat",
+    "--without-bz2lib",
+    "--without-iconv",
+    "--without-zlib",
+    "--disable-bsdtar",
+    "--disable-bsdcpio",
+    "--without-lzmadec",
+    "--without-openssl",
+  ]
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: env
   command "make install", env: env
 end

--- a/config/software/libiconv.rb
+++ b/config/software/libiconv.rb
@@ -63,9 +63,10 @@ build do
   update_config_guess(target: "build-aux")
   update_config_guess(target: "libcharset/build-aux")
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-static", env: env
+  configure_options = [
+    " --disable-static",
+  ]
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: env
   command "make -j #{workers} install-lib libdir=#{install_dir}/embedded/lib includedir=#{install_dir}/embedded/include", env: env
 end

--- a/config/software/libpcap.rb
+++ b/config/software/libpcap.rb
@@ -37,7 +37,7 @@ env["PATH"] = "#{install_dir}/embedded/bin" + File::PATH_SEPARATOR + ENV["PATH"]
 build do
   license "BSD-3-Clause"
   license_file "https://gist.githubusercontent.com/truthbk/b06f2ea54f6f297c599e/raw/e1fc035d3114cd43e55fabcddd073e20307c129e/libpcap.license"
-  command "./configure --prefix=#{install_dir}/embedded", env: env
+  configure env: env
   command "make -j #{workers}", env: env
   command "make -j #{workers} install", env: env
 end

--- a/config/software/libsqlite3.rb
+++ b/config/software/libsqlite3.rb
@@ -9,12 +9,11 @@ source url: "https://www.sqlite.org/2023/sqlite-autoconf-3430101.tar.gz",
 
 relative_path "sqlite-autoconf-3430100"
 
-env = with_standard_compiler_flags(with_embedded_path)
-
 build do
   license "Public-Domain"
 
   update_config_guess
+  env = with_standard_compiler_flags(with_embedded_path)
   configure_options = [
     "--disable-nls",
     "--disable-static",

--- a/config/software/libyaml.rb
+++ b/config/software/libyaml.rb
@@ -34,10 +34,11 @@ build do
 
   update_config_guess(target: "config")
 
-  command "./configure " \
-          " --enable-shared" \
-          " --disable-static" \
-          " --prefix=#{install_dir}/embedded", env: env
+  configure_options = [
+    " --enable-shared",
+    " --disable-static",
+  ]
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: env
   command "make -j #{workers} install", env: env
 end

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -27,34 +27,7 @@ relative_path "makedepend-1.0.5"
 dependency "xproto"
 dependency "util-macros"
 
-configure_env =
-  case ohai["platform"]
-  when "aix"
-    {
-      "CC" => "xlc -q64",
-      "CXX" => "xlC -q64",
-      "LD" => "ld -b64",
-      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
-      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
-      "OBJECT_MODE" => "64",
-      "ARFLAGS" => "-X64 cru",
-    }
-  when "mac_os_x"
-    {
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib",
-    }
-  when "solaris2"
-    {
-      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    }
-  else
-    {
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib",
-    }
-  end
+configure_env = with_standard_compiler_flags(with_embedded_path)
 
 configure_env["PKG_CONFIG_LIBDIR"] = "#{install_dir}/embedded/lib/pkgconfig" +
   File::PATH_SEPARATOR +

--- a/config/software/makedepend.rb
+++ b/config/software/makedepend.rb
@@ -64,7 +64,7 @@ build do
   license "BSD-3-Clause"
   license_file "https://raw.githubusercontent.com/ioerror/makedepend/master/LICENSE"
 
-  command "./configure --prefix=#{install_dir}/embedded", env: configure_env
+  configure env: configure_env
   command "make -j #{workers}", env: configure_env
   command "make -j #{workers} install", env: configure_env
 end

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -57,39 +57,37 @@ build do
   update_config_guess
 
   # build wide-character libraries
-  cmd_array = ["./configure",
-           "--prefix=#{install_dir}/embedded",
-           "--with-shared",
-           "--disable-static",
-           "--with-termlib",
-           "--without-debug",
-           "--without-normal", # AIX doesn't like building static libs
-           "--without-cxx-binding",
-           "--enable-overwrite",
-           "--enable-widec",
-           "--without-manpages",
-           "--without-tests"]
+  configure_options = [
+    "--with-shared",
+    "--disable-static",
+    "--with-termlib",
+    "--without-debug",
+    "--without-normal", # AIX doesn't like building static libs
+    "--without-cxx-binding",
+    "--enable-overwrite",
+    "--enable-widec",
+    "--without-manpages",
+    "--without-tests",
+  ]
 
-  cmd_array << "--with-libtool" if ohai["platform"] == "aix"
-  command(cmd_array.join(" "),
-    env: env)
+  configure_options << "--with-libtool" if ohai["platform"] == "aix"
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: env
   command "make -j #{workers} install", env: env
 
   # build non-wide-character libraries
   command "make distclean"
-  cmd_array = ["./configure",
-           "--prefix=#{install_dir}/embedded",
-           "--with-shared",
-           "--disable-static",
-           "--with-termlib",
-           "--without-debug",
-           "--without-normal",
-           "--without-cxx-binding",
-           "--enable-overwrite"]
-  cmd_array << "--with-libtool" if ohai["platform"] == "aix"
-  command(cmd_array.join(" "),
-    env: env)
+  configure_options = [
+    "--with-shared",
+    "--disable-static",
+    "--with-termlib",
+    "--without-debug",
+    "--without-normal",
+    "--without-cxx-binding",
+    "--enable-overwrite",
+  ]
+  configure_options << "--with-libtool" if ohai["platform"] == "aix"
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: env
 
   # installing the non-wide libraries will also install the non-wide

--- a/config/software/nghttp2.rb
+++ b/config/software/nghttp2.rb
@@ -18,15 +18,16 @@ build do
   license "MIT"
   license_file "./COPYING"
 
-  command [
-    "./configure",
+  env = with_standard_compiler_flags(with_embedded_path)
+
+  configure_options = [
     "--disable-static",
     "--enable-shared",
     "--disable-app",
     "--disable-examples",
     "--disable-hpack-tools",
-    "--prefix=#{install_dir}/embedded",
-  ].join(" ")
-  command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
+  ]
+  configure(*configure_options, env: env)
+  command "make -j #{workers}", env: env
   command "make install"
 end

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -50,20 +50,17 @@ end
 source url: "https://ftp.postgresql.org/pub/source/v#{version}/postgresql-#{version}.tar.bz2"
 relative_path "postgresql-#{version}"
 
-configure_env = {
-  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-}
-
 build do
-  command ["./configure",
-           "--prefix=#{install_dir}/embedded",
+  env = with_standard_compiler_flags(with_embedded_path)
+  configure_options = [
            "--without-readline",
-           "--with-openssl --with-includes=#{install_dir}/embedded/include",
+           "--with-openssl",
+           "--with-includes=#{install_dir}/embedded/include",
            "--without-icu",
-           "--with-libraries=#{install_dir}/embedded/lib"].join(" "), env: configure_env
-  command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
+           "--with-libraries=#{install_dir}/embedded/lib",
+  ]
+  configure(*configure_options, env: env)
+  command "make -j #{workers}"
   command "make install"
 
   delete "#{install_dir}/embedded/lib/postgresql/pgxs/src/test/"

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -28,12 +28,11 @@ build do
   end
 
   command("./autogen.sh", env: env)
-  command(["./configure",
-           "--prefix=#{install_dir}/embedded",
-           "--without-ncurses",
-           "--disable-nls",
-           ""].join(" "),
-    env: env)
+  configure_options = [
+    "--without-ncurses",
+    "--disable-nls",
+  ]
+  configure *configure_options, env: env
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
 

--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -8,12 +8,6 @@ source url:    "https://gitlab.com/procps-ng/procps/-/archive/v3.3.16/procps-v#{
 
 relative_path "procps-v#{version}"
 
-env = {
-  "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-  "LD_RUN_PATH" => "#{install_dir}/embedded/lib",
-}
-
 build do
   license "GPL-2.0"
   license_file "https://gitlab.com/procps-ng/procps/raw/master/COPYING"
@@ -27,12 +21,13 @@ build do
     f.puts "#{version}"
   end
 
+  env = with_standard_compiler_flags(with_embedded_path)
   command("./autogen.sh", env: env)
   configure_options = [
     "--without-ncurses",
     "--disable-nls",
   ]
-  configure *configure_options, env: env
+  configure(*configure_options, env: env)
   command "make -j #{workers}", env: { "LD_RUN_PATH" => "#{install_dir}/embedded/lib" }
   command "make install"
 

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -41,9 +41,10 @@ build do
   license "MIT"
   license_file "./COPYING"
 
-  command "./configure" \
-          " --prefix=#{install_dir}/embedded" \
-          " --disable-static", env: configure_env
+  configure_options = [
+    "--disable-static",
+  ]
+  configure *configure_options, env: configure_env
   command "make -j #{workers}", env: configure_env
   command "make -j #{workers} install", env: configure_env
 end

--- a/config/software/xproto.rb
+++ b/config/software/xproto.rb
@@ -8,34 +8,7 @@ source url: "https://xorg.freedesktop.org/releases/individual/proto/xproto-#{ver
 
 relative_path "xproto-#{version}"
 
-configure_env =
-  case ohai["platform"]
-  when "aix"
-    {
-      "CC" => "xlc -q64",
-      "CXX" => "xlC -q64",
-      "CFLAGS" => "-q64 -I#{install_dir}/embedded/include -O",
-      "LDFLAGS" => "-q64 -Wl,-blibpath:/usr/lib:/lib",
-      "ARFLAGS" => "-X64 cru",
-      "LD" => "ld -b64",
-      "OBJECT_MODE" => "64",
-    }
-  when "mac_os_x"
-    {
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib",
-    }
-  when "solaris2"
-    {
-      "LDFLAGS" => "-R#{install_dir}/embedded/lib -L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include -static-libgcc",
-      "CFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-    }
-  else
-    {
-      "LDFLAGS" => "-L#{install_dir}/embedded/lib -I#{install_dir}/embedded/include",
-      "CFLAGS" => "-I#{install_dir}/embedded/include -L#{install_dir}/embedded/lib",
-    }
-  end
+configure_env = with_standard_compiler_flags(with_embedded_path)
 
 build do
   license "MIT"
@@ -44,7 +17,7 @@ build do
   configure_options = [
     "--disable-static",
   ]
-  configure *configure_options, env: configure_env
+  configure(*configure_options, env: configure_env)
   command "make -j #{workers}", env: configure_env
   command "make -j #{workers} install", env: configure_env
 end

--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -68,11 +68,7 @@ build do
     end
 
     env["CFLAGS"] << " -fPIC"
-
-    configure env: env
-
-    make "-j #{workers}", env: env
-    make "-j #{workers} install", env: env
+    cmake env: env
 
     delete "#{install_dir}/embedded/lib/libz.a"
     delete "#{install_dir}/embedded/share/man/man3/zlib.3"


### PR DESCRIPTION
The intent is to use the same wrappers as much as possible, in order to have a single place to update to change the way we use autotools and cmake.
This change makes it easier to switch to a custom toolchain, by only changing the 2 wrappers, instead of sprinkling environment variable throughout all our recipes