### PR TITLE
Bump Zlib version to 1.3.1

### DIFF
--- a/config/software/zlib.rb
+++ b/config/software/zlib.rb
@@ -15,10 +15,10 @@
 #
 
 name "zlib"
-default_version "1.3"
+default_version "1.3.1"
 
-version "1.3" do
-  source sha256: "ff0ba4c292013dbc27530b3a81e1f9a813cd39de01ca5e0f8bf355702efa593e"
+version "1.3.1" do
+  source sha256: "9a93b2b7dfdac77ceba5a558a580e74667dd6fede4585b91eefb60f03b72df23"
 end
 
 source url: "https://zlib.net/fossils/zlib-#{version}.tar.gz",


### PR DESCRIPTION
Bump Zlib to the latest version. We (ASC) need it for the FIPS Proxy