### PR TITLE
openssl: bump to 3.0.13 (#505)

### DIFF
--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -24,7 +24,7 @@ dependency "zlib"
 dependency "cacerts"
 dependency "makedepend" unless windows?
 
-default_version "3.0.12"
+default_version "3.0.13"
 
 source url: "https://www.openssl.org/source/openssl-#{version}.tar.gz", extract: :lax_tar
 
@@ -33,6 +33,7 @@ version("3.0.9") { source sha256: "eb1ab04781474360f77c318ab89d8c5a03abc38e63d65
 version("3.0.8") { source sha256: "6c13d2bf38fdf31eac3ce2a347073673f5d63263398f1f69d0df4a41253e4b3e" }
 version("3.0.11") { source sha256: "b3425d3bb4a2218d0697eb41f7fc0cdede016ed19ca49d168b78e8d947887f55" }
 version("3.0.12") { source sha256: "f93c9e8edde5e9166119de31755fc87b4aa34863662f67ddfcba14d0b6b69b61" }
+version("3.0.13") { source sha256: "88525753f79d3bec27d2fa7c66aa0b92b3aa9498dafd93d7cfa4b3780cdae313" }
 
 relative_path "openssl-#{version}"
 


### PR DESCRIPTION
(cherry picked from commit fcd374ae322102d4fcd91a0e7dd4ec5726cdcfb7)

https://datadoghq.atlassian.net/browse/VULN-5166