### PR TITLE
CI: fix job rules to avoid running on_success job in case of failure

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -7,17 +7,16 @@ stages:
   - notify
 
 .skip_stable_branches: &skip_stable_branches
-  rules:
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
-      when: never
-    - if: $CI_COMMIT_BRANCH =~ /^7.[0-9]{2}.x/
-      when: never
-    - if: $CI_COMMIT_TAG != null
-      when: never
-    - when: on_success
+  - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+    when: never
+  - if: $CI_COMMIT_BRANCH =~ /^7.[0-9]{2}.x/
+    when: never
+  - if: $CI_COMMIT_TAG != null
+    when: never
 
 trigger-agent-build:
-  <<: *skip_stable_branches
+  rules: *skip_stable_branches
+    - when: always
   stage: test
   trigger:
     project: datadog/datadog-agent
@@ -28,7 +27,8 @@ trigger-agent-build:
     RUN_KITCHEN_TESTS: "true"
 
 on_success:
-  <<: *skip_stable_branches
+  rules: *skip_stable_branches
+    - when: on_success
   stage: after-test
   needs: ["trigger-agent-build"]
   tags: ["arch:amd64"]
@@ -41,11 +41,11 @@ on_success:
     expire_in: 1 week
 
 check-downstream-pipeline:
-  <<: *skip_stable_branches
+  rules: *skip_stable_branches
+    - when: always
   stage: check-downstream
   tags: ["arch:amd64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v19805261-b468a29
-  when: always
   script:
     - cat output.pipeline
 
@@ -53,7 +53,8 @@ notify:
   extends: .slack-notifier-base
   stage: notify
   dependencies: []
-  <<: *skip_stable_branches
+  rules: *skip_stable_branches
+    - when: always
   script: |
     export MESSAGE="Your omnibus-software test pipeline completed"
     /usr/local/bin/notify.sh

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,8 @@ stages:
     when: never
 
 trigger-agent-build:
-  rules: *skip_stable_branches
+  rules:
+    - *skip_stable_branches
     - when: always
   stage: test
   trigger:
@@ -27,7 +28,8 @@ trigger-agent-build:
     RUN_KITCHEN_TESTS: "true"
 
 on_success:
-  rules: *skip_stable_branches
+  rules:
+    - *skip_stable_branches
     - when: on_success
   stage: after-test
   needs: ["trigger-agent-build"]
@@ -41,7 +43,8 @@ on_success:
     expire_in: 1 week
 
 check-downstream-pipeline:
-  rules: *skip_stable_branches
+  rules:
+    - *skip_stable_branches
     - when: always
   stage: check-downstream
   tags: ["arch:amd64"]
@@ -53,7 +56,8 @@ notify:
   extends: .slack-notifier-base
   stage: notify
   dependencies: []
-  rules: *skip_stable_branches
+  rules:
+    - *skip_stable_branches
     - when: always
   script: |
     export MESSAGE="Your omnibus-software test pipeline completed"

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -14,7 +14,7 @@ stages:
       when: never
     - if: $CI_COMMIT_TAG != null
       when: never
-    - when: always
+    - when: on_success
 
 trigger-agent-build:
   <<: *skip_stable_branches
@@ -33,7 +33,6 @@ on_success:
   needs: ["trigger-agent-build"]
   tags: ["arch:amd64"]
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v19805261-b468a29
-  when: on_success
   script:
     - echo success > output.pipeline
   artifacts:


### PR DESCRIPTION
The `rules` mark the job as always ran, which defeats the purpose of the `on_success` `when` clause for the `on_success` job.

