### PR TITLE
[CI] Deprecate qa/skip-qa label

### DIFF
--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -80,5 +80,5 @@ jobs:
           body: >
             Automatically created by merging ${{ github.event.pull_request.html_url }}
 
-            :warning: This PR is opened with the skip-qa labels by default. Please make sure this is appropriate
+            :warning: This PR is opened with the qa/no-code-change label by default. Please make sure this is appropriate
 

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -76,7 +76,7 @@ jobs:
           commit-message: 'omnibus: bump OMNIBUS_SOFTWARE_VERSION'
           title: '[omnibus][automated] Bump OMNIBUS_SOFTWARE_VERSION'
           branch: 'automated/omnibus-software/${{ github.event.number }}'
-          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change,qa/skip-qa'
+          labels: 'team/agent-platform,changelog/no-changelog,qa/no-code-change'
           body: >
             Automatically created by merging ${{ github.event.pull_request.html_url }}
 


### PR DESCRIPTION
`qa/skip-qa` -> `qa/no-code-change` in the auto pr creation in the datadog-agent repo.