### PR TITLE
Bump libxml2

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -26,7 +26,7 @@ dependency "liblzma"
 dependency "config_guess"
 
 # version_list: url=https://download.gnome.org/sources/libxml2/2.9/ filter=*.tar.xz
-version("2.10.3") { source sha256: "5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c" }
+version("2.12.6") { source sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb" }
 
 source url: "https://download.gnome.org/sources/libxml2/2.10/libxml2-#{version}.tar.xz"
 


### PR DESCRIPTION
Fix [VULNOPS-1340](https://datadoghq.atlassian.net/browse/VULNOPS-1340?atlOrigin=eyJpIjoiODk5NzU4YThlZTg2NDlhMTkzZjliOGFiYjkwYjI2YmIiLCJwIjoiamlyYS1zbGFjay1pbnQifQ).

See https://github.com/DataDog/integrations-core/pull/17432 for reference. In future releases this dependency will probably not be taken from this Omnibus definition but built into a Python dependency on integrations-core.

[VULNOPS-1340]: https://datadoghq.atlassian.net/browse/VULNOPS-1340?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ