### PR TITLE
Revert "Bump libxml2"

### DIFF
--- a/config/software/libxml2.rb
+++ b/config/software/libxml2.rb
@@ -26,7 +26,7 @@ dependency "liblzma"
 dependency "config_guess"
 
 # version_list: url=https://download.gnome.org/sources/libxml2/2.9/ filter=*.tar.xz
-version("2.12.6") { source sha256: "889c593a881a3db5fdd96cc9318c87df34eb648edfc458272ad46fd607353fbb" }
+version("2.10.3") { source sha256: "5d2cc3d78bec3dbe212a9d7fa629ada25a7da928af432c93060ff5c17ee28a9c" }
 
 source url: "https://download.gnome.org/sources/libxml2/2.10/libxml2-#{version}.tar.xz"
 


### PR DESCRIPTION
#519 contains a mistake; fixing as attempted in #520/#522 results in [compilation errors for openscap](https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/495397785#L2340).