### PR TITLE
Drop postgresql as a dependency for unixodbc

### DIFF
--- a/config/software/unixodbc.rb
+++ b/config/software/unixodbc.rb
@@ -4,16 +4,6 @@ default_version "2.3.9"
 version("2.3.7") { source sha256: "45f169ba1f454a72b8fcbb82abd832630a3bf93baa84731cf2949f449e1e3e77" }
 version("2.3.9") { source sha256: "52833eac3d681c8b0c9a5a65f2ebd745b3a964f208fc748f977e44015a31b207" }
 
-# This is a very ugly hack - due to numerous conflicting macros (in unixodbc
-# installed headers and postgresql headers used during build), it is almost
-# impossible to build postgresql when unixodbc is already installed. For
-# example, we hit https://trac.macports.org/ticket/4559.
-# Therefore we make unixodbc depend on postgresql to ensure postgresql is
-# always built first.
-# We do require postgresql everywhere where we need unixodbc, so there's
-# no harm in doing that.
-dependency "postgresql"
-
 source url: "https://www.unixodbc.org/unixODBC-#{version}.tar.gz"
 
 relative_path "unixODBC-#{version}"


### PR DESCRIPTION
As far as I understand, we no longer need to ship postgresql explicitly with the Agent after https://github.com/DataDog/datadog-agent/pull/23094, as we're now building it and bundling it as necessary with integration dependencies.