### PR TITLE
libffi: use an HTTPS mirror

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -27,7 +27,7 @@ dependency "libtool" unless windows?
 
 version("3.2.1") { source sha256: "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37" }
 
-source url: "ftp://sourceware.org/pub/libffi/libffi-#{version}.tar.gz"
+source url: "https://sourceware.org/ftp/libffi/libffi-#{version}.tar.gz"
 
 relative_path "libffi-#{version}"
 


### PR DESCRIPTION
We seem to sometimes have errors when fetching from FTP: https://gitlab.ddbuild.io/DataDog/datadog-agent/-/jobs/536079168