### PR TITLE
chore(github): reduce workflow token permission

### DIFF
--- a/.github/workflows/no-auto-bump.yml
+++ b/.github/workflows/no-auto-bump.yml
@@ -5,6 +5,8 @@ on:
       - opened
       - synchronize
 
+permissions: {}
+
 jobs:
   labeler:
     permissions:

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -5,10 +5,17 @@ on:
     types:
       - closed
 
+permissions: {}
+
 jobs:
   open_bump_pr:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+      pull-requests: write
+
     steps:
       - name: Create Token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -57,7 +57,7 @@ jobs:
         id: new_sha
         run: |
           git fetch
-          NEW_SHA=$(git rev-parse f4usto/set-least-permissions-to-github-token-on-workflows)
+          NEW_SHA=$(git rev-parse origin/f4usto/set-least-permissions-to-github-token-on-workflows)
           echo NEW_SHA=${NEW_SHA} >> "${GITHUB_OUTPUT}"
 
       - name: Update release.json

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -12,10 +12,6 @@ jobs:
     if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
-    permissions:
-      contents: read
-      pull-requests: write
-
     steps:
       - name: Create Token
         uses: actions/create-github-app-token@v1

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -3,13 +3,13 @@ run-name:
 on:
   pull_request:
     types:
-      - closed
+      - assigned
 
 permissions: {}
 
 jobs:
   open_bump_pr:
-    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') && github.ref == 'refs/heads/master'
+    # if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -3,13 +3,13 @@ run-name:
 on:
   pull_request:
     types:
-      - assigned
+      - closed
 
 permissions: {}
 
 jobs:
   open_bump_pr:
-    # if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') && github.ref == 'refs/heads/master'
+    if: github.event.pull_request.merged == true && !contains(github.event.pull_request.labels.*.name, 'no-auto-bump') && github.ref == 'refs/heads/master'
     runs-on: ubuntu-latest
 
     steps:
@@ -57,7 +57,7 @@ jobs:
         id: new_sha
         run: |
           git fetch
-          NEW_SHA=$(git rev-parse origin/f4usto/set-least-permissions-to-github-token-on-workflows)
+          NEW_SHA=$(git rev-parse origin/master)
           echo NEW_SHA=${NEW_SHA} >> "${GITHUB_OUTPUT}"
 
       - name: Update release.json

--- a/.github/workflows/open-datadog-agent-pr.yml
+++ b/.github/workflows/open-datadog-agent-pr.yml
@@ -57,7 +57,7 @@ jobs:
         id: new_sha
         run: |
           git fetch
-          NEW_SHA=$(git rev-parse origin/master)
+          NEW_SHA=$(git rev-parse f4usto/set-least-permissions-to-github-token-on-workflows)
           echo NEW_SHA=${NEW_SHA} >> "${GITHUB_OUTPUT}"
 
       - name: Update release.json


### PR DESCRIPTION
Github token permissions should follow the least privilege principle

Reset workflow permissions to validate we can enable read-only default permissions at repository level to provide a strong baseline protection measure