### PR TITLE
openssl: drop makedepend dependency

### DIFF
--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -22,7 +22,6 @@ skip_transitive_dependency_licensing true
 
 dependency "zlib"
 dependency "cacerts"
-dependency "makedepend" unless aix? || windows?
 
 default_version "1.1.1u"
 

--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -22,7 +22,6 @@ skip_transitive_dependency_licensing true
 
 dependency "zlib"
 dependency "cacerts"
-dependency "makedepend" unless windows?
 
 default_version "3.3.1"
 


### PR DESCRIPTION
This is a build tool that can be installed in the build image directly, but as it turns out, it just isn't required :shrug: 