### PR TITLE
Fix Python build dependencies

### DIFF
--- a/config/patches/bzip2/soname_install_dir.patch
+++ b/config/patches/bzip2/soname_install_dir.patch
@@ -5,7 +5,7 @@
  
  all: $(OBJS)
 -	$(CC) -shared -Wl,-soname -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
-+	$(CC) -shared -Wl,-install_name -Wl,libbz2.so.1.0 -o libbz2.so.1.0.8 $(OBJS)
++	$(CC) -shared -Wl,-install_name -Wl,'@rpath/libbz2.so.1.0' -o libbz2.so.1.0.8 $(OBJS)
  	$(CC) $(CFLAGS) -o bzip2-shared bzip2.c libbz2.so.1.0.8
  	rm -f libbz2.so.1.0
  	ln -s libbz2.so.1.0.8 libbz2.so.1.0

--- a/config/software/bzip2.rb
+++ b/config/software/bzip2.rb
@@ -53,4 +53,14 @@ build do
   make "#{args} -f Makefile-libbz2_so", env: env
   make "#{args} install", env: env
   delete "#{install_dir}/embedded/lib/libbz2.a"
+
+  # The version of bzip2 we use doesn't create a pkgconfig file,
+  # we add it here manually (needed at least by the Python build)
+  erb source: "bzip2.pc.erb",
+      dest: "#{install_dir}/embedded/lib/pkgconfig/bzip2.pc",
+      vars: {
+        prefix: File.join(install_dir, "embedded"),
+        version: version,
+      }
+
 end

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -33,21 +33,6 @@ relative_path "ncurses-#{version}"
 env = with_embedded_path
 env = with_standard_compiler_flags(env, aix: { use_gcc: true })
 
-########################################################################
-#
-# wide-character support:
-# Ruby 1.9 optimistically builds against libncursesw for UTF-8
-# support. In order to prevent Ruby from linking against a
-# package-installed version of ncursesw, we build wide-character
-# support into ncurses with the "--enable-widec" configure parameter.
-# To support other applications and libraries that still try to link
-# against libncurses, we also have to create non-wide libraries.
-#
-# The methods below are adapted from:
-# http://www.linuxfromscratch.org/lfs/view/development/chapter06/ncurses.html
-#
-########################################################################
-
 build do
   license "MIT"
   license_file "https://gist.githubusercontent.com/remh/41a4f7433c77841c302c/raw/d15db09a192ca0e51022005bfb4c3a414a996896/ncurse.LICENSE"
@@ -56,27 +41,7 @@ build do
 
   update_config_guess
 
-  # build non-wide-character libraries
-  configure_options = [
-    "--with-shared",
-    "--disable-static",
-    "--with-termlib",
-    "--without-debug",
-    "--without-normal",
-    "--without-cxx-binding",
-    "--enable-overwrite",
-  ]
-  configure_options << "--with-libtool" if ohai["platform"] == "aix"
-  configure(*configure_options, env: env)
-  command "make -j #{workers}", env: env
-
-  # installing the non-wide libraries will also install the non-wide
-  # binaries, which doesn't happen to be a problem since we don't
-  # utilize the ncurses binaries in private-chef (or oss chef)
-  command "make -j #{workers} install", env: env
-
   # build wide-character libraries
-  command "make distclean"
   configure_options = [
     "--with-shared",
     "--disable-static",
@@ -86,6 +51,7 @@ build do
     "--without-cxx-binding",
     "--enable-overwrite",
     "--enable-widec",
+    "--enable-pc-files",
     "--without-manpages",
     "--without-tests",
   ]
@@ -94,6 +60,9 @@ build do
   configure(*configure_options, env: env)
   command "make -j #{workers}", env: env
   command "make -j #{workers} install", env: env
+
+  # Python's detection seems to expect to fiind a ncurses.pc rather than ncursesw.pc
+  link "#{install_dir}/embedded/lib/pkgconfig/ncursesw.pc", "#{install_dir}/embedded/lib/pkgconfig/ncurses.pc"
 
   # Ensure embedded ncurses wins in the LD search path
   if ohai["platform"] == "smartos"

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -56,27 +56,7 @@ build do
 
   update_config_guess
 
-  # build wide-character libraries
-  configure_options = [
-    "--with-shared",
-    "--disable-static",
-    "--with-termlib",
-    "--without-debug",
-    "--without-normal", # AIX doesn't like building static libs
-    "--without-cxx-binding",
-    "--enable-overwrite",
-    "--enable-widec",
-    "--without-manpages",
-    "--without-tests",
-  ]
-
-  configure_options << "--with-libtool" if ohai["platform"] == "aix"
-  configure(*configure_options, env: env)
-  command "make -j #{workers}", env: env
-  command "make -j #{workers} install", env: env
-
   # build non-wide-character libraries
-  command "make distclean"
   configure_options = [
     "--with-shared",
     "--disable-static",
@@ -93,6 +73,26 @@ build do
   # installing the non-wide libraries will also install the non-wide
   # binaries, which doesn't happen to be a problem since we don't
   # utilize the ncurses binaries in private-chef (or oss chef)
+  command "make -j #{workers} install", env: env
+
+  # build wide-character libraries
+  command "make distclean"
+  configure_options = [
+    "--with-shared",
+    "--disable-static",
+    "--with-termlib",
+    "--without-debug",
+    "--without-normal", # AIX doesn't like building static libs
+    "--without-cxx-binding",
+    "--enable-overwrite",
+    "--enable-widec",
+    "--without-manpages",
+    "--without-tests",
+  ]
+
+  configure_options << "--with-libtool" if ohai["platform"] == "aix"
+  configure(*configure_options, env: env)
+  command "make -j #{workers}", env: env
   command "make -j #{workers} install", env: env
 
   # Ensure embedded ncurses wins in the LD search path

--- a/config/templates/bzip2/bzip2.pc.erb
+++ b/config/templates/bzip2/bzip2.pc.erb
@@ -1,0 +1,11 @@
+prefix=<%= prefix %>
+exec_prefix=${prefix}
+bindir=${prefix}/bin
+libdir=${prefix}/lib
+includedir=${prefix}/include
+
+Name: bzip2
+Description: Lossless, block-sorting data compression
+Version: <%= version %>
+Libs: -L${libdir} -lbz2
+Cflags: -I${includedir}


### PR DESCRIPTION
[BARX-563](https://datadoghq.atlassian.net/browse/BARX-563)

This makes the build of Python 3.12 work on macOS (https://github.com/DataDog/datadog-agent-macos-build/actions/runs/10826570028/job/30037807223).

I'll probably have a more complete write-up of it elsewhere at some point, but I'll try to summarize things here.

The crux of the matter is that Python 3.12 introduced significant changes in their build system (notably incorporating the use of pkgconfig in module detection) which broke some things on our build.
- ncurses:
  - IIUC The Python build now assumes that on macOS, if ncurses is found, it must be with wide char support (without checking further). As it turns out, we were building both a wide and a non-wide version of ncurses, but the non-wide version's header overwrote the include file, meaning that Python failed to find the wide char functions while compiling, thus breaking the build. Note that this probably means that we've been linking to the non-wide version all along, at least on MacOS. I've decided to just remove the non-wide version; if we really need it at some point, we may want to create separate definitions and make sure we handle potential conflicts safely.
  - For some reason, that change resulted in ncurses not being correctly detected during Python's configure step (which relies on pkg-config). Adding a configure flag and making sure the .pc file exists with the expected name made the trick here.
- bzip2:
  - This one is interesting because it looks like we weren't really including the `_bz2` module that we ship bzip2 for (at least on MacOS), and that's why we hadn't issues before. I'm not yet sure why that has somewhat changed.
  - Since I saw that pkg-config was also not detecting bzip2, I added the .pc file via an erb template.
  - The install-name set in the patch includes just the library name, which causes macOS' dyld to not find the library at runtime (it's not on any known search path). I made this relative to the rpath so that it can be found.

[BARX-563]: https://datadoghq.atlassian.net/browse/BARX-563?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ