### PR TITLE
curl: don't hardcode path to dependencies

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -46,9 +46,9 @@ build do
            "--without-gnutls",
            "--without-librtmp",
            "--without-libssh2",
-           "--with-ssl=#{install_dir}/embedded",
-           "--with-zlib=#{install_dir}/embedded",
-           "--with-nghttp2=#{install_dir}/embedded",
+           "--with-ssl",
+           "--with-zlib",
+           "--with-nghttp2",
   ]
   configure(*configure_options, env: env)
 


### PR DESCRIPTION
This fix a potential issue (most likely only in more recent toolchains
than the one we use in the build images) where curl would explicitly
depend on the absolute path to its dependencies, causing it to link with
/path/to/libfoo.so instead of -lfoo
When linking with an absolute path, the linker appears to not include
the rpath information, which causes linking errors down the line:
```
2023-10-25T15:16:09+00:00 | /opt/toolchains/bin/../lib/gcc/x86_64-unknown-linux-gnu/11.4.0/../../../../x86_64-unknown-linux-gnu/bin/ld.bfd: warning: libnghttp2.so.14, needed by
../lib/.libs/libcurl.so, not found (try using -rpath or -rpath-link)
```
