### PR TITLE
Changed ECR -> registry.ddbuild.io and updated build images

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ on_success:
     - job: "trigger-agent-build"
       optional: true
   tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v19805261-b468a29
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48866977-9bfad02c
   script:
     - echo success > output.pipeline
   artifacts:
@@ -81,7 +81,7 @@ check-downstream-pipeline:
     - when: always
   stage: check-downstream
   tags: ["arch:amd64"]
-  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/datadog-agent-buildimages/deb_x64:v19805261-b468a29
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48866977-9bfad02c
   script:
     - cat output.pipeline
 

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -57,7 +57,7 @@ on_success:
     - job: "trigger-agent-build"
       optional: true
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48866977-9bfad02c
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48815877-9bfad02c
   script:
     - echo success > output.pipeline
   artifacts:
@@ -81,7 +81,7 @@ check-downstream-pipeline:
     - when: always
   stage: check-downstream
   tags: ["arch:amd64"]
-  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48866977-9bfad02c
+  image: registry.ddbuild.io/ci/datadog-agent-buildimages/deb_x64:v48815877-9bfad02c
   script:
     - cat output.pipeline
 


### PR DESCRIPTION
Buildimages are now pushed to registry.ddbuild.io, replaced ECR by this (https://github.com/DataDog/datadog-agent-buildimages/pull/708).