### PR TITLE
drop OMNIBUS_OPENSSL_SOFTWARE environment variable

### DIFF
--- a/config/software/curl.rb
+++ b/config/software/curl.rb
@@ -19,7 +19,7 @@ name "curl"
 default_version "8.9.1"
 
 dependency "zlib"
-dependency ENV["OMNIBUS_OPENSSL_SOFTWARE"] || "openssl"
+dependency "openssl3"
 dependency "nghttp2"
 source url:    "https://curl.haxx.se/download/curl-#{version}.tar.gz",
        sha256: "291124a007ee5111997825940b3876b3048f7d31e73e9caa681b80fe48b2dcd5"

--- a/config/software/postgresql.rb
+++ b/config/software/postgresql.rb
@@ -19,7 +19,7 @@ name "postgresql"
 default_version "16.0"
 
 dependency "zlib"
-dependency ENV["OMNIBUS_OPENSSL_SOFTWARE"] || "openssl"
+dependency "openssl3"
 
 version "16.0" do
   source sha256: "df9e823eb22330444e1d48e52cc65135a652a6fdb3ce325e3f08549339f51b99"


### PR DESCRIPTION
This is causing OpenSSL 1 to be used since the introduction of https://github.com/DataDog/datadog-agent/pull/30983