### PR TITLE
macOS arm64 support

### DIFF
--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -16,7 +16,7 @@
 
 name "libffi"
 
-default_version "3.2.1"
+default_version "3.4.6"
 
 license "MIT"
 license_file "LICENSE"
@@ -25,7 +25,7 @@ skip_transitive_dependency_licensing true
 # Is libtool actually necessary? Doesn't configure generate one?
 dependency "libtool" unless windows?
 
-version("3.2.1") { source sha256: "d06ebb8e1d9a22d19e38d63fdb83954253f39bedc5d46232a05645685722ca37" }
+version("3.4.6") { source sha256: "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e" }
 
 source url: "https://sourceware.org/ftp/libffi/libffi-#{version}.tar.gz"
 

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -27,7 +27,7 @@ dependency "libtool" unless windows?
 
 version("3.4.6") { source sha256: "b0dea9df23c863a7a50e825440f3ebffabd65df1497108e5d437747843895a4e" }
 
-source url: "https://sourceware.org/ftp/libffi/libffi-#{version}.tar.gz"
+source url: "https://github.com/libffi/libffi/releases/download/v#{version}/libffi-#{version}.tar.gz"
 
 relative_path "libffi-#{version}"
 

--- a/config/software/libffi.rb
+++ b/config/software/libffi.rb
@@ -60,7 +60,7 @@ build do
   end
 
   # libffi's default install location of header files is awful...
-  mkdir "#{install_dir}/embedded/include"
-  copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
+  #mkdir "#{install_dir}/embedded/include"
+  #copy "#{install_dir}/embedded/lib/libffi-#{version}/include/*", "#{install_dir}/embedded/include/"
 
 end

--- a/config/software/openssl.rb
+++ b/config/software/openssl.rb
@@ -97,8 +97,10 @@ build do
   configure_cmd =
     if aix?
       "perl ./Configure aix64-cc"
-    elsif mac_os_x?
+    elsif mac_os_x? && !ohai["kernel"]["machine"].start_with?("arm")
       "./Configure darwin64-x86_64-cc"
+    elsif mac_os_x?
+      "./Configure darwin64-arm64-cc"
     elsif smartos?
       "/bin/bash ./Configure solaris64-x86_64-gcc -static-libgcc"
     elsif omnios?

--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -74,8 +74,10 @@ build do
   end
 
   configure_cmd =
-    if mac_os_x?
+    if mac_os_x? && !ohai["kernel"]["machine"].start_with?("arm")
       "./Configure darwin64-x86_64-cc"
+    elsif mac_os_x?
+      "./Configure darwin64-arm64"
     elsif windows?
       platform = windows_arch_i386? ? "mingw" : "mingw64"
       "perl.exe ./Configure #{platform}"


### PR DESCRIPTION
Add macOS arm64 support
  - Bump libffi to 3.4.6 which supports M1
  - Edit configure options