### PR TITLE
openssl: explicitely install applink.c since python needs it

### DIFF
--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -100,5 +100,7 @@ build do
     # Remove openssl static libraries here as we can't disable those at build time
     delete "#{install_dir}/embedded/lib/libcrypto.a"
     delete "#{install_dir}/embedded/lib/libssl.a"
+  else
+    copy "ms/applink.c", "#{install_dir}/embedded/include/openssl"
   end
 end


### PR DESCRIPTION
Python build system expects this file to be present, so we want to install it