### PR TITLE
openssl: don't provide prefix with its default value

### DIFF
--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -55,7 +55,6 @@ build do
   end
 
   configure_args = [
-    "--prefix=#{install_dir}/embedded",
     "--with-zlib-lib=#{install_dir}/embedded/lib",
     "--with-zlib-include=#{install_dir}/embedded/include",
     "--libdir=lib",


### PR DESCRIPTION
The `configure` command already provides this value internally.
We will need to update it for windows, but we can do so globally for all softwares if we stop providing the value explicitly.