### PR TITLE
openssl: use configure function instead of manual command

### DIFF
--- a/config/software/openssl3.rb
+++ b/config/software/openssl3.rb
@@ -87,7 +87,7 @@ build do
   # the crazy platform specific compiler flags at the end.
   configure_args << env["CFLAGS"] << env["LDFLAGS"]
 
-  configure *configure_args, bin: configure_cmd, env: env, no_build_triplet: true
+  configure(*configure_args, bin: configure_cmd, env: env, no_build_triplet: true)
 
   command "make depend", env: env
   command "make -j #{workers}", env: env


### PR DESCRIPTION
Switch to the usual `configure` function which will provide the correct prefix on windows (and also just because it centralizes configure invocations)

This will install OpenSSL in the expected location on Windows