### PR TITLE
libarchive: don't build static library

### DIFF
--- a/config/software/libarchive.rb
+++ b/config/software/libarchive.rb
@@ -41,6 +41,7 @@ build do
     "--disable-bsdcpio",
     "--without-lzmadec",
     "--without-openssl",
+    "--disable-static",
   ]
   configure(*configure_options, env: env)
   command "make -j #{workers}", env: env


### PR DESCRIPTION
This is 1MB we don't need