### PR TITLE
ncurses: don't build programs nor term DB

### DIFF
--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -54,6 +54,8 @@ build do
     "--enable-pc-files",
     "--without-manpages",
     "--without-tests",
+    "--without-progs",
+    "--disable-database",
   ]
 
   configure_options << "--with-libtool" if ohai["platform"] == "aix"

--- a/config/software/ncurses.rb
+++ b/config/software/ncurses.rb
@@ -55,7 +55,7 @@ build do
     "--without-manpages",
     "--without-tests",
     "--without-progs",
-    "--disable-database",
+    "--disable-db-install",
   ]
 
   configure_options << "--with-libtool" if ohai["platform"] == "aix"


### PR DESCRIPTION
We only need the lib, and I doubt we really need the term database since I don't expect the agent to ever wait for user input or display fancy ncurses interfaces