### PR TITLE
procps-ng: only ship the source offer

### DIFF
--- a/config/software/procps-ng.rb
+++ b/config/software/procps-ng.rb
@@ -1,7 +1,7 @@
 name "procps-ng"
 default_version "3.3.16"
 
-ship_source true
+ship_source_offer true
 
 source url:    "https://gitlab.com/procps-ng/procps/-/archive/v3.3.16/procps-v#{version}.tar.gz",
        sha256: "7f09945e73beac5b12e163a7ee4cae98bcdd9a505163b6a060756f462907ebbc"


### PR DESCRIPTION
Instead of the full sources