### PR TITLE
CI: run a downstream pipeline in case a patch gets updated

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -16,6 +16,7 @@ stages:
     when: never
   - changes:
     - "**/*.rb"
+    - "config/patches/**"
     - Rakefile
     - omnibus-software.gemspec
     - Gemfile


### PR DESCRIPTION
Avoid surprising results such as https://gitlab.ddbuild.io/DataDog/omnibus-software/-/pipelines/54026398 where only a patch changes.